### PR TITLE
Delete jails in case of plugin install failure

### DIFF
--- a/iocage_cli/fetch.py
+++ b/iocage_cli/fetch.py
@@ -60,6 +60,8 @@ def validate_count(ctx, param, value):
               help="Specify the files to fetch from the mirror.")
 @click.option("--server", "-s", default="download.freebsd.org",
               help="Server to fetch from.")
+@click.option("--keep_jail_on_failure", "-k", default=False,
+              help="Keep jails on failure")
 @click.option("--user", "-u", default="anonymous", help="The user to use.")
 @click.option(
     "--password", "-p", default="anonymous@", help="The password to use.")

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -57,7 +57,7 @@ class IOCPlugin(object):
     """
 
     def __init__(self, release=None, plugin=None, branch=None,
-                 callback=None, silent=False, keep_jail_on_failure=False,
+                 keep_jail_on_failure=False, callback=None, silent=False,
                  **kwargs):
         self.pool = iocage_lib.ioc_json.IOCJson().json_get_value("pool")
         self.iocroot = iocage_lib.ioc_json.IOCJson(
@@ -130,7 +130,7 @@ class IOCPlugin(object):
             self.__fetch_plugin_install_packages__(jail_name, jaildir, conf,
                                                    _conf, pkg, props, repo_dir)
             self.__fetch_plugin_post_install__(conf, _conf, jaildir, jail_name)
-        except (KeyboardInterrupt, SystemExit) as e:
+        except (KeyboardInterrupt, SystemExit, RuntimeError) as e:
             if isinstance(e, KeyboardInterrupt) or not self.keep_jail_on_failure:
                 iocage_lib.ioc_destroy.IOCDestroy().destroy_jail(location)
             sys.exit(1)

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -819,6 +819,7 @@ class IOCage(object):
         _long = kwargs.pop("_long", False)
         official = kwargs.pop("official", False)
         branch = kwargs.pop("branch", None)
+        keep_jail_on_failure = kwargs.pop("keep_jail_on_failure", False)
 
         freebsd_version = ioc_common.checkoutput(["freebsd-version"])
         arch = os.uname()[4]
@@ -881,13 +882,17 @@ class IOCage(object):
             if count == 1:
                 ioc_plugin.IOCPlugin(
                     release=release, branch=branch,
-                    silent=self.silent, callback=self.callback, **kwargs
+                    silent=self.silent,
+                    keep_jail_on_failure=keep_jail_on_failure,
+                    callback=self.callback, **kwargs
                 ).fetch_plugin(name, props, 0, accept)
             else:
                 for j in range(1, count + 1):
                     ioc_plugin.IOCPlugin(
                         release=release, branch=branch,
-                        silent=self.silent, callback=self.callback, **kwargs
+                        silent=self.silent,
+                        keep_jail_on_failure=keep_jail_on_failure,
+                        callback=self.callback, **kwargs
                     ).fetch_plugin(name, props, j, accept)
         else:
             if _list:


### PR DESCRIPTION
This commit adds support for deleting jails by default incase a plugin install fails. However a user can still have the jail intact if a flag is specified for that behaviour.
Ticket: #41694