### PR TITLE
Change devfs rule generation

### DIFF
--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -643,3 +643,68 @@ def check_release_newer(release, callback=None, silent=False):
             },
             _callback=callback,
             silent=silent)
+
+
+def construct_devfs(ruleset_name, paths, includes=None, comment=None):
+    """
+    ruleset_name: The ruleset without the brackets or a number,
+        for example 'foo' will be contructed into [foo=IOCAGE_GEN_RULENUM]
+
+    Will construct a devfs ruleset from dict(paths), and list(includes) with:
+        paths dict:
+            EXAMPLE: "usbctl": mode 660 group uucp
+            - path to unhide: mode (can be None)
+        includes list:
+            EXAMPLE ["$devfsrules_hide_all", "$devfsrules_unhide_basic"]
+            - [entry, entry]
+
+    Returns a tuple containing the string and which devfs_ruleset got assigned.
+    """
+    includes = [] if includes is None else includes
+    ct_str = f'## {ruleset_name}' if comment is None else comment
+    rules = []
+    ruleset_number = 5  # The system has 4 already claimed.
+
+    try:
+        with open('/etc/devfs.rules', 'r') as f:
+            exists = False
+
+            for line in f.readlines():
+                if line.rstrip() == ct_str:
+                    exists = True
+                    continue
+
+                if exists:
+                    return None, int(line.rsplit('=')[1].strip(']\n'))
+
+                if '[' in line:
+                    line = int(line.rsplit('=')[1].strip(']\n'))
+                    rules.append(line)
+    except FileNotFoundError:
+        logit(
+            {
+                'level': 'EXCEPTION',
+                'message':
+                    '/etc/devfs.rules could not be found, unable to continue.'
+            }
+        )
+
+    while ruleset_number in rules:
+            ruleset_number += 1
+
+    devfs_string = f'\n{ct_str}\n[{ruleset_name}={ruleset_number}]'
+
+    for include in includes:
+        devfs_string += f'\nadd include {include}'
+
+    for path, mode in paths.items():
+        path_str = f'add path \'{path}\''
+
+        if mode is not None:
+            path_str += f' {mode}'
+        else:
+            path_str += ' unhide'
+
+        devfs_string += f'\n{path_str}'
+
+    return f'{devfs_string}\n', str(ruleset_number)

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -690,7 +690,7 @@ def construct_devfs(ruleset_name, paths, includes=None, comment=None):
         )
 
     while ruleset_number in rules:
-            ruleset_number += 1
+        ruleset_number += 1
 
     devfs_string = f'\n{ct_str}\n[{ruleset_name}={ruleset_number}]'
 

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -124,6 +124,42 @@ class IOCPlugin(object):
         location = f"{self.iocroot}/jails/{jail_name}"
 
         try:
+            devfs = conf.get("devfs_ruleset", None)
+
+            if devfs is not None:
+                devfs_cmd = ["service", "devfs", "restart"]
+                plugin_devfs = devfs[f'plugin_{jail_name}']
+                plugin_devfs_paths = plugin_devfs['paths']
+
+                for prop in props:
+                    key, _, value = prop.partition("=")
+
+                    if key == "dhcp" and value == "on":
+                        if 'bpf*' not in plugin_devfs_paths:
+                            plugin_devfs_paths["bpf*"] = None
+
+                plugin_devfs_includes = None if 'includes' not in plugin_devfs\
+                    else plugin_devfs['includes']
+
+                with open("/etc/devfs.rules", "a+") as devfs:
+                    # Same plugin, so the name being unique as it might become
+                    # later does not matter
+                    devfs_str, devfs_rule = \
+                        iocage_lib.ioc_common.construct_devfs(
+                            f'plugin_{jail_name}',
+                            paths=plugin_devfs_paths,
+                            includes=plugin_devfs_includes
+                        )
+
+                    if 'bpf*' in plugin_devfs_paths:
+                        # Plugin needs to use it now
+                        props += [f'devfs_ruleset={devfs_rule}']
+
+                    if devfs_str is not None:
+                        devfs.write(devfs_str)
+                        su.check_call(devfs_cmd, stdout=su.PIPE,
+                                      stderr=su.PIPE)
+
             jail_name, jaildir, _conf, repo_dir = self.__fetch_plugin_create__(
                 props, jail_name)
             location = f"{self.iocroot}/jails/{jail_name}"
@@ -517,6 +553,9 @@ fingerprint: {fingerprint}
                 silent=self.silent)
 
             self.__clone_repo(conf['artifact'], f'{jaildir}/plugin')
+
+            with open(f"{jaildir}/{uuid.rsplit('_', 1)[0]}.json", "w") as f:
+                f.write(json.dumps(conf, indent=4, sort_keys=True))
 
             try:
                 distutils.dir_util.copy_tree(

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -27,6 +27,7 @@ import hashlib
 import os
 import re
 import shutil
+import json
 import subprocess as su
 import netifaces
 
@@ -156,7 +157,7 @@ class IOCStart(object):
                     silent=self.silent)
 
             self.__check_dhcp__()
-            devfs_ruleset = "5" if devfs_ruleset == "4" else devfs_ruleset
+            devfs_ruleset = None if devfs_ruleset == "4" else devfs_ruleset
 
         if mount_procfs == "1":
             su.Popen(["mount", "-t", "procfs", "proc", self.path +
@@ -256,8 +257,47 @@ class IOCStart(object):
 
             vnet = True
 
-        if bpf == "yes":
-            self.__generate_bpf_ruleset()
+        if self.conf["type"] == "pluginv2" and os.path.isfile(
+                f"{self.path}/{self.uuid.rsplit('_', 1)[0]}.json"):
+            devfs_cmd = ["service", "devfs", "restart"]
+
+            with open(f"{self.path}/{self.uuid.rsplit('_', 1)[0]}.json",
+                      "r") as f:
+                plugin_name = self.uuid.rsplit('_', 1)[0]
+                devfs_json = json.load(f)
+                plugin_devfs = devfs_json[
+                    "devfs_ruleset"][f'plugin_{plugin_name}']
+                plugin_devfs_paths = plugin_devfs['paths']
+
+                if dhcp == "on":
+                    if 'bpf*' not in plugin_devfs_paths:
+                        plugin_devfs_paths["bpf*"] = None
+
+                plugin_devfs_includes = None if 'includes' not in plugin_devfs\
+                    else plugin_devfs['includes']
+
+            with open("/etc/devfs.rules", "a+") as devfs:
+                # Same plugin, so the name being unique as it might become
+                # later does not matter
+                devfs_str, devfs_rule = \
+                    iocage_lib.ioc_common.construct_devfs(
+                        f'plugin_{plugin_name}',
+                        paths=plugin_devfs_paths,
+                        includes=plugin_devfs_includes
+                    )
+
+                if 'bpf*' in plugin_devfs_paths:
+                    # Plugin needs to use it now
+                    devfs_ruleset = devfs_rule
+
+                if devfs_str is not None:
+                    devfs.write(devfs_str)
+                    su.check_call(devfs_cmd, stdout=su.PIPE,
+                                  stderr=su.PIPE)
+
+                generated_devfs_ruleset = devfs_rule
+        else:
+            generated_devfs_ruleset = self.__generate_dhcp_ruleset()
 
         msg = f"* Starting {self.uuid}"
         iocage_lib.ioc_common.logit({
@@ -267,14 +307,18 @@ class IOCStart(object):
             _callback=self.callback,
             silent=self.silent)
 
-        if devfs_ruleset != "5" and dhcp == "on":
-            iocage_lib.ioc_common.logit({
-                "level": "WARNING",
-                "message": "  You are not using the iocage devfs_ruleset"
-                           " of 5, DHCP may not work."
-            },
-                _callback=self.callback,
-                silent=self.silent)
+        if devfs_ruleset is None and dhcp == "on":
+            devfs_ruleset = generated_devfs_ruleset
+        elif generated_devfs_ruleset != devfs_ruleset and dhcp == "on":
+            if self.conf["type"] != "pluginv2" and devfs_ruleset != "4":
+                iocage_lib.ioc_common.logit({
+                    "level": "WARNING",
+                    "message": f"  {self.uuid} is not using the devfs_ruleset"
+                               f" of {generated_devfs_ruleset},"
+                               " DHCP may not work."
+                },
+                    _callback=self.callback,
+                    silent=self.silent)
 
         start_cmd = [x for x in ["jail", "-c"] + net +
                           [f"name=ioc-{self.uuid}",
@@ -790,31 +834,35 @@ class IOCStart(object):
         return mac_a, mac_b
 
     @staticmethod
-    def __generate_bpf_ruleset():
+    def __generate_dhcp_ruleset():
         """
         Will add the bpf ruleset to the hosts /etc/devfs.rules if it doesn't
         exist, otherwise it will do nothing.
         """
         devfs_cmd = ["service", "devfs", "restart"]
-        bpf_ruleset = """
-## IOCAGE -- Add DHCP to ruleset 4
-[devfsrules_jail_dhcp=5]
-add include $devfsrules_hide_all
-add include $devfsrules_unhide_basic
-add include $devfsrules_unhide_login
-add path zfs unhide
-add path 'bpf*' unhide
-"""
-        with open("/etc/devfs.rules", "a+") as devfs:
-            devfs.seek(0, 0)
+        devfs_dict = {
+            'zfs': None,
+            'bpf*': None
+        }
+        devfs_includes = [
+            '$devfsrules_hide_all',
+            '$devfsrules_unhide_basic',
+            '$devfsrules_unhide_login'
+        ]
 
-            for line in devfs:
-                if "## IOCAGE -- Add DHCP to ruleset 4" in line:
-                    break
-            else:
-                # Not found, else is ran if break statement isn't executed
-                devfs.write(bpf_ruleset)
-                su.check_call(devfs_cmd, stdout=su.PIPE, stderr=su.PIPE)
+        with open("/etc/devfs.rules", "a+") as devfs:
+                devfs_str, devfs_rule = iocage_lib.ioc_common.construct_devfs(
+                    'devfsrules_jail_dhcp',
+                    paths=devfs_dict,
+                    includes=devfs_includes,
+                    comment='## IOCAGE -- Add DHCP to ruleset 4'
+                )
+
+                if devfs_str is not None:
+                    devfs.write(devfs_str)
+                    su.check_call(devfs_cmd, stdout=su.PIPE, stderr=su.PIPE)
+
+        return devfs_rule
 
     def __check_dhcp__(self):
         nic_list = self.get("interfaces").split(",")

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -265,37 +265,40 @@ class IOCStart(object):
                       "r") as f:
                 plugin_name = self.uuid.rsplit('_', 1)[0]
                 devfs_json = json.load(f)
-                plugin_devfs = devfs_json[
-                    "devfs_ruleset"][f'plugin_{plugin_name}']
-                plugin_devfs_paths = plugin_devfs['paths']
+                if "devfs_ruleset" not in devfs_json:
+                    generated_devfs_ruleset = self.__generate_dhcp_ruleset()
+                else:
+                    plugin_devfs = devfs_json[
+                        "devfs_ruleset"][f"plugin_{plugin_name}"]
+                    plugin_devfs_paths = plugin_devfs['paths']
 
-                if dhcp == "on":
-                    if 'bpf*' not in plugin_devfs_paths:
-                        plugin_devfs_paths["bpf*"] = None
+                    if dhcp == "on":
+                        if 'bpf*' not in plugin_devfs_paths:
+                            plugin_devfs_paths["bpf*"] = None
 
-                plugin_devfs_includes = None if 'includes' not in plugin_devfs\
-                    else plugin_devfs['includes']
+                    plugin_devfs_includes = None if 'includes' not in \
+                        plugin_devfs else plugin_devfs['includes']
 
-            with open("/etc/devfs.rules", "a+") as devfs:
-                # Same plugin, so the name being unique as it might become
-                # later does not matter
-                devfs_str, devfs_rule = \
-                    iocage_lib.ioc_common.construct_devfs(
-                        f'plugin_{plugin_name}',
-                        paths=plugin_devfs_paths,
-                        includes=plugin_devfs_includes
-                    )
+                    with open("/etc/devfs.rules", "a+") as devfs:
+                        # Same plugin, so the name being unique as it might
+                        # become later does not matter
+                        devfs_str, devfs_rule = \
+                            iocage_lib.ioc_common.construct_devfs(
+                                f'plugin_{plugin_name}',
+                                paths=plugin_devfs_paths,
+                                includes=plugin_devfs_includes
+                            )
 
-                if 'bpf*' in plugin_devfs_paths:
-                    # Plugin needs to use it now
-                    devfs_ruleset = devfs_rule
+                        if 'bpf*' in plugin_devfs_paths:
+                            # Plugin needs to use it now
+                            devfs_ruleset = devfs_rule
 
-                if devfs_str is not None:
-                    devfs.write(devfs_str)
-                    su.check_call(devfs_cmd, stdout=su.PIPE,
-                                  stderr=su.PIPE)
+                        if devfs_str is not None:
+                            devfs.write(devfs_str)
+                            su.check_call(devfs_cmd, stdout=su.PIPE,
+                                          stderr=su.PIPE)
 
-                generated_devfs_ruleset = devfs_rule
+                        generated_devfs_ruleset = devfs_rule
         else:
             generated_devfs_ruleset = self.__generate_dhcp_ruleset()
 
@@ -851,16 +854,16 @@ class IOCStart(object):
         ]
 
         with open("/etc/devfs.rules", "a+") as devfs:
-                devfs_str, devfs_rule = iocage_lib.ioc_common.construct_devfs(
-                    'devfsrules_jail_dhcp',
-                    paths=devfs_dict,
-                    includes=devfs_includes,
-                    comment='## IOCAGE -- Add DHCP to ruleset 4'
-                )
+            devfs_str, devfs_rule = iocage_lib.ioc_common.construct_devfs(
+                'devfsrules_jail_dhcp',
+                paths=devfs_dict,
+                includes=devfs_includes,
+                comment='## IOCAGE -- Add DHCP to ruleset 4'
+            )
 
-                if devfs_str is not None:
-                    devfs.write(devfs_str)
-                    su.check_call(devfs_cmd, stdout=su.PIPE, stderr=su.PIPE)
+            if devfs_str is not None:
+                devfs.write(devfs_str)
+                su.check_call(devfs_cmd, stdout=su.PIPE, stderr=su.PIPE)
 
         return devfs_rule
 


### PR DESCRIPTION
- DHCP is much more flexible now
- Plugins are able to have devfs rules specified in their manifests
- Plugin manifests are kept around for devfs rules now, possibly more fun later

Ticket: #42593