### PR TITLE
Only show one interface for the plugin IP

### DIFF
--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -503,7 +503,7 @@ fingerprint: {fingerprint}
             dhcp = True
             ip = ""
 
-        os.environ["IOCAGE_PLUGIN_IP"] = ip
+        os.environ["IOCAGE_PLUGIN_IP"] = ip.rsplit(',')[0]
 
         # We need to pipe from tar to the root of the jail.
 
@@ -578,7 +578,8 @@ fingerprint: {fingerprint}
                 try:
                     with open(ui_json, "r") as u:
                         admin_portal = json.load(u)["adminportal"]
-                        admin_portal = admin_portal.replace("%%IP%%", ip)
+                        admin_portal = admin_portal.replace("%%IP%%",
+                                                            ip.rsplit(',')[0])
                         iocage_lib.ioc_common.logit(
                             {
                                 "level": "INFO",


### PR DESCRIPTION
Most plugins that have more then one IP use VNET, so this assumes the first interface to be the default one.

Ticket: #42641