### PR TITLE
Fixed a bug in fstab

### DIFF
--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -970,7 +970,7 @@ class IOCage(object):
             if add_path:
                 destination = f"{self.iocroot}/jails/{uuid}/root{destination}"
 
-            if len(destination) > 88:
+            if destination and len(destination) > 88:
                 ioc_common.logit(
                     {
                         "level":


### PR DESCRIPTION
This commit fixes a bug which caused iocage to raise an exception incase an edit/removal was required by index only and destination field was passed on as null in fstab.
Ticket: #45783

