### PR TITLE
Test variable before splitting again, honor IP only for plugin install

### DIFF
--- a/iocage_lib/ioc_list.py
+++ b/iocage_lib/ioc_list.py
@@ -245,8 +245,11 @@ class IOCList(object):
 
                 try:
                     with open(f"{mountpoint}/plugin/ui.json", "r") as u:
-                        ip = full_ip4.split("|", 1)[1].split("/", 1)[
-                            0] if "DHCP" not in full_ip4 else "DHCP"
+                        ip = full_ip4.split("|", 1)
+                        ip = ip[1] if len(ip) != 1 else ip[0]
+
+                        ip = ip.split("/", 1)[0] if "DHCP" not in full_ip4 \
+                            else "DHCP"
                         admin_portal = json.load(u)["adminportal"]
                         admin_portal = admin_portal.replace("%%IP%%", ip)
                 except FileNotFoundError:

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -521,15 +521,13 @@ fingerprint: {fingerprint}
         """Fetches the users artifact and runs the post install"""
         dhcp = False
 
-        try:
-            ip4 = _conf["ip4_addr"].split("|")[1].rsplit("/")[0]
-        except IndexError:
-            ip4 = "none"
+        ip4 = _conf["ip4_addr"]
+        if '|' in ip4:
+            ip4 = ip4.split("|")[1].rsplit("/")[0]
 
-        try:
-            ip6 = _conf["ip6_addr"].split("|")[1].rsplit("/")[0]
-        except IndexError:
-            ip6 = "none"
+        ip6 = _conf["ip6_addr"]
+        if '|' in ip6:
+            ip6 = ip6.split("|")[1].rsplit("/")[0]
 
         if ip4 != "none":
             ip = ip4


### PR DESCRIPTION
This would be fatal if they didn't supply an interface, in addition we don't care about the interface here, so these block's aren't useful.

Ticket: #41670