### PR TITLE
Improve validation for VNET MAC Fields

### DIFF
--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -353,7 +353,7 @@ class IOCCreate(object):
                 is_template = True
 
             try:
-                iocjson.json_check_prop(key, value, config)
+                value, config = iocjson.json_check_prop(key, value, config)
 
                 config[key] = value
             except RuntimeError as err:

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -1232,6 +1232,32 @@ class IOCJson(object):
                             conf[key] = value
                     except ValueError:
                         pass
+                elif key in [f'vnet{i}_mac' for i in range(0, 4)]:
+                    if value and value != 'none':
+                        value = value.replace(',', ' ')
+                        if (
+                            any(
+                                not re.match(
+                                    "[0-9a-f]{2}([-:]?)[0-9a-f]{2}(\\1[0-9a-f]{2}){4}$",
+                                    v.lower()
+                                ) for v in value.split()
+                            ) or
+                            len(value.split()) != 2 or
+                            any(value.split().count(v) > 1 for v in value.split())
+                        ):
+                            iocage_lib.ioc_common.logit(
+                                {
+                                    'level': 'EXCEPTION',
+                                    'message': 'Please Enter two valid and different '
+                                               f'space/comma-delimited MAC addresses for {key}.'
+                                },
+                                _callback=self.callback,
+                                silent=self.silent
+                            )
+                    elif not value:
+                        # Let's standardise the value to none in case
+                        # vnetX_mac is not provided
+                        value = 'none'
 
                 return value, conf
             else:

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -843,7 +843,7 @@ class IOCStart(object):
             mac_a, mac_b = self.__generate_mac_address_pair(nic)
             self.set(f"{nic}_mac={mac_a},{mac_b}")
         else:
-            mac_a, mac_b = mac.split(",")
+            mac_a, mac_b = mac.split()
 
         return mac_a, mac_b
 


### PR DESCRIPTION
This commit improves validation for vnet mac props by ensuring that a valid mac address is specified each time with taking into account that the addresses aren't repeated.
Ticket: #45838
