### PR TITLE
Fix devfs rules that have a bracket

### DIFF
--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -677,8 +677,11 @@ def construct_devfs(ruleset_name, paths, includes=None, comment=None):
                 if exists:
                     return None, int(line.rsplit('=')[1].strip(']\n'))
 
-                if '[' in line:
-                    line = int(line.rsplit('=')[1].strip(']\n'))
+                if line.startswith('['):
+                    try:
+                        line = int(line.rsplit('=')[1].strip(']\n'))
+                    except IndexError:
+                        rules.append(line)
                     rules.append(line)
     except FileNotFoundError:
         logit(


### PR DESCRIPTION
add path 'ulpt[0-9]*' mode 666 and such.

Ticket: #46920