### PR TITLE
Make default interface for vnet customizable

### DIFF
--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -521,6 +521,7 @@ class IOCCreate(object):
         jail_props["jail_zfs_dataset"] = f"iocage/jails/{jail_uuid}/data"
         jail_props["depends"] = "none"
         jail_props["vnet_interfaces"] = "none"
+        jail_props["vnet_default_interface"] = "none"
 
         return jail_props
 

--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -521,7 +521,6 @@ class IOCCreate(object):
         jail_props["jail_zfs_dataset"] = f"iocage/jails/{jail_uuid}/data"
         jail_props["depends"] = "none"
         jail_props["vnet_interfaces"] = "none"
-        jail_props["vnet_default_interface"] = "none"
 
         return jail_props
 

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -1026,7 +1026,7 @@ class IOCJson(object):
         conf["hostid_strict_check"] = hostid_strict_check
 
         # Version 12 keys
-        if not conf.get('vnet_default_interface', None):
+        if not conf.get('vnet_default_interface'):
             conf['vnet_default_interface'] = 'none'
 
         if not default:
@@ -1275,7 +1275,7 @@ class IOCJson(object):
                         # Let's standardise the value to none in case
                         # vnetX_mac is not provided
                         value = 'none'
-                elif key == 'vnet_default_interface':
+                elif key == 'vnet_default_interface' and value != 'none':
                     if value not in netifaces.interfaces():
                         iocage_lib.ioc_common.logit(
                             {
@@ -1687,6 +1687,7 @@ class IOCJson(object):
                 "vnet1_mac": "none",
                 "vnet2_mac": "none",
                 "vnet3_mac": "none",
+                "vnet_default_interface": "none",
                 "devfs_ruleset": "4",
                 "exec_start": "/bin/sh /etc/rc",
                 "exec_stop": "/bin/sh /etc/rc.shutdown",

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -829,7 +829,7 @@ class IOCJson(object):
     @staticmethod
     def json_get_version():
         """Sets the iocage configuration version."""
-        version = "11"
+        version = "12"
 
         return version
 
@@ -1025,6 +1025,10 @@ class IOCJson(object):
         # Set all keys, even if it's the same value.
         conf["hostid_strict_check"] = hostid_strict_check
 
+        # Version 12 keys
+        if not conf.get('vnet_default_interface', None):
+            conf['vnet_default_interface'] = 'none'
+
         if not default:
             try:
                 if not renamed:
@@ -1180,6 +1184,7 @@ class IOCJson(object):
             "mount_procfs": ("0", "1"),
             "mount_linprocfs": ("0", "1"),
             "vnet": ("off", "on"),
+            "vnet_default_interface": ("string", ),
             "template": ("no", "yes"),
             "comment": ("string", ),
             "host_time": ("no", "yes"),
@@ -1270,6 +1275,17 @@ class IOCJson(object):
                         # Let's standardise the value to none in case
                         # vnetX_mac is not provided
                         value = 'none'
+                elif key == 'vnet_default_interface':
+                    if value not in netifaces.interfaces():
+                        iocage_lib.ioc_common.logit(
+                            {
+                                'level': 'EXCEPTION',
+                                'message': 'Please provide a valid NIC to be used '
+                                           'with vnet'
+                            },
+                            _callback=self.callback,
+                            silent=self.silent
+                        )
 
                 return value, conf
             else:

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -932,7 +932,17 @@ class IOCStart(object):
 
     def get_default_gateway(self):
         # e.g response - ('192.168.122.1', 'lagg0')
-        return netifaces.gateways()["default"][netifaces.AF_INET]
+        try:
+            return netifaces.gateways()["default"][netifaces.AF_INET]
+        except KeyError:
+            iocage_lib.ioc_common.logit(
+                {
+                    'level': 'EXCEPTION',
+                    'message': 'No default gateway interface found'
+                },
+                _callback=self.callback,
+                silent=self.silent
+            )
 
     def get_bridge_members(self, bridge):
         return [


### PR DESCRIPTION
This commit adds support for customizing the default interface for vnet which should be attached on the relevant bridge. It updates the properties of the jails by adding a new property which is used when starting vnet jails.
Ticket: #40484
