### PR TITLE
Bug fix for MAC Addresses

### DIFF
--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -841,9 +841,9 @@ class IOCStart(object):
 
         if mac == "none":
             mac_a, mac_b = self.__generate_mac_address_pair(nic)
-            self.set(f"{nic}_mac={mac_a},{mac_b}")
+            self.set(f"{nic}_mac={mac_a} {mac_b}")
         else:
-            mac_a, mac_b = mac.split()
+            mac_a, mac_b = mac.replace(',', ' ').split()
 
         return mac_a, mac_b
 


### PR DESCRIPTION
This commit fixes a bug which resulted in a traceback when a comma was present in the mac addresses.
Ticket: #47085
