### PR TITLE
Large rework to Exec interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@ SERVER=""
 SRC_BASE?="/usr/src"
 
 install:
-	echo -e "import os\ntry:\n  if not os.listdir('$(SRC_BASE)'): exit('$(SRC_BASE) must be populated!')\nexcept FileNotFoundError:\n  exit('$(SRC_BASE) must be populated!')" | python3.6
+	echo -e "import os\ntry:\n  if not os.listdir('$(SRC_BASE)'): exit('$(SRC_BASE) must be populated!')\nexcept FileNotFoundError:\n  exit('$(SRC_BASE) must be populated!')" | python3
 	test -d .git && git pull || true
 	test -d .git && git submodule init py-libzfs && git submodule update py-libzfs || true
-	python3.6 -m ensurepip
+	python3 -m ensurepip
 	export FREEBSD_SRC=$(SRC_BASE) && cd py-libzfs && python3.6 setup.py build && python3.6 setup.py install
-	python3.6 -m pip install -U .
+	python3 -m pip install -U .
 uninstall:
-	python3.6 -m pip uninstall -y iocage-lib iocage-cli
+	python3 -m pip uninstall -y iocage-lib iocage-cli
 test:
 	pytest --zpool $(ZPOOL) --server $(SERVER)
 help:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install:
 	test -d .git && git pull || true
 	test -d .git && git submodule init py-libzfs && git submodule update py-libzfs || true
 	python3 -m ensurepip
-	export FREEBSD_SRC=$(SRC_BASE) && cd py-libzfs && python3.6 setup.py build && python3.6 setup.py install
+	export FREEBSD_SRC=$(SRC_BASE) && cd py-libzfs && python3 setup.py build && python3 setup.py install
 	python3 -m pip install -U .
 uninstall:
 	python3 -m pip uninstall -y iocage-lib iocage-cli

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install:
 	test -d .git && git pull || true
 	test -d .git && git submodule init py-libzfs && git submodule update py-libzfs || true
 	python3 -m ensurepip
-	export FREEBSD_SRC=$(SRC_BASE) && cd py-libzfs && python3 setup.py build && python3 setup.py install
+	export FREEBSD_SRC=$(SRC_BASE) && cd py-libzfs && ./configure && python3 setup.py build && python3 setup.py install
 	python3 -m pip install -U .
 uninstall:
 	python3 -m pip uninstall -y iocage-lib iocage-cli

--- a/iocage
+++ b/iocage
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3.6
+#!/usr/local/bin/python3
 # -*- coding: utf-8 -*-
 
 import re

--- a/iocage_cli/exec.py
+++ b/iocage_cli/exec.py
@@ -58,4 +58,14 @@ def cli(command, jail, host_user, jail_user):
     # unsetting the convenience default
     host_user = "" if jail_user and host_user == "root" else host_user
 
-    ioc.IOCage(jail=jail).exec(command, host_user, jail_user)
+    try:
+        ioc.IOCage(jail=jail).exec(
+            command, host_user, jail_user, interactive=True)
+    except KeyboardInterrupt:
+        pass
+    except Exception as e:
+        ioc_common.logit({
+            'level': 'EXCEPTION',
+            'message': 'Command failed!\n'
+                       f'Exception: "{e.__class__.__name__}:{str(e)}" occured'
+        })

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -772,10 +772,31 @@ def match_to_dir(iocroot, uuid, old_uuid=None):
         return None
 
 
-def consume(exec_gen):
+def consume_and_log(exec_gen, return_list=False, callback=None, silent=False):
     """
-    The idea is to consume a generator without caring about it's output
-    such as the DNS queries with plugins
+    Consume a generator and massage the output with lines
     """
-    for _ in exec_gen:
-        pass
+    final_output = ''
+    output_list = []
+
+    for stdout, _ in exec_gen:
+        if silent:
+            continue
+
+        final_output += stdout.decode()
+
+        if not final_output.endswith('\n'):
+            continue
+
+        if return_list:
+            output_list.append(final_output.rstrip())
+        else:
+            logit({
+                "level": "INFO",
+                "message": final_output.rstrip()
+            },
+                _callback=callback)
+        final_output = ''
+
+    if return_list:
+        return output_list

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -770,3 +770,12 @@ def match_to_dir(iocroot, uuid, old_uuid=None):
         return matches[0]
     else:
         return None
+
+
+def consume(exec_gen):
+    """
+    The idea is to consume a generator without caring about it's output
+    such as the DNS queries with plugins
+    """
+    for _ in exec_gen:
+        pass

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -772,7 +772,7 @@ def match_to_dir(iocroot, uuid, old_uuid=None):
         return None
 
 
-def consume_and_log(exec_gen, return_list=False, callback=None, silent=False):
+def consume_and_log(exec_gen, log=True, callback=None):
     """
     Consume a generator and massage the output with lines
     """
@@ -780,17 +780,14 @@ def consume_and_log(exec_gen, return_list=False, callback=None, silent=False):
     output_list = []
 
     for stdout, _ in exec_gen:
-        if silent:
-            continue
-
         final_output += stdout.decode()
 
         if not final_output.endswith('\n'):
             continue
 
-        if return_list:
-            output_list.append(final_output.rstrip())
-        else:
+        output_list.append(final_output.rstrip())
+
+        if log:
             logit({
                 "level": "INFO",
                 "message": final_output.rstrip()
@@ -798,5 +795,4 @@ def consume_and_log(exec_gen, return_list=False, callback=None, silent=False):
                 _callback=callback)
         final_output = ''
 
-    if return_list:
-        return output_list
+    return output_list

--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -41,6 +41,7 @@ import iocage_lib.ioc_exceptions
 import libzfs
 import itertools
 import dns.resolver
+import dns.exception
 
 
 class IOCCreate(object):
@@ -560,9 +561,17 @@ class IOCCreate(object):
                 dns.resolver.query(repo)
             except dns.resolver.NoNameservers:
                 iocage_lib.ioc_common.logit({
-                    "level": "EXCEPTION",
-                    "message": f"{repo} could not be reached via DNS, check"
-                    " your network"
+                    'level': 'EXCEPTION',
+                    'message': f'{repo} could not be reached via DNS, check'
+                    ' your network'
+                },
+                    _callback=self.callback,
+                    silent=False)
+            except dns.exception.DNSException as e:
+                iocage_lib.ioc_common.logit({
+                    'level': 'EXCEPTION',
+                    'message': f'DNS Exception: {e}\n'
+                    f'{repo} could not be reached via DNS, check your network'
                 },
                     _callback=self.callback,
                     silent=False)

--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -580,12 +580,9 @@ class IOCCreate(object):
             silent=False)
 
         try:
-            with iocage_lib.ioc_exec.IOCExec(
+            iocage_lib.ioc_exec.SilentExec(
                 srv_connect_cmd, jail_uuid, location, plugin=self.plugin
-            ) as _exec:
-                out = _exec.exec_jail()
-                iocage_lib.ioc_common.consume_and_log(out, silent=True)
-
+            )
         except iocage_lib.ioc_exceptions.CommandFailed:
             # This shouldn't be fatal since SRV records are not required
             iocage_lib.ioc_common.logit({
@@ -603,11 +600,9 @@ class IOCCreate(object):
             _callback=self.callback,
             silent=False)
         try:
-            with iocage_lib.ioc_exec.IOCExec(
+            iocage_lib.ioc_exec.SilentExec(
                 dnssec_connect_cmd, jail_uuid, location, plugin=self.plugin,
-            ) as _exec:
-                out = _exec.exec_jail()
-                iocage_lib.ioc_common.consume_and_log(out, silent=True)
+            )
         except iocage_lib.ioc_exceptions.CommandFailed:
             # Not fatal, they may not be using DNSSEC
             iocage_lib.ioc_common.logit({
@@ -625,11 +620,9 @@ class IOCCreate(object):
                 silent=False)
 
             try:
-                with iocage_lib.ioc_exec.IOCExec(
+                iocage_lib.ioc_exec.SilentExec(
                     dns_connect_cmd, jail_uuid, location, plugin=self.plugin,
-                ) as _exec:
-                    out = _exec.exec_jail()
-                    iocage_lib.ioc_common.consume_and_log(out, silent=True)
+                )
             except iocage_lib.ioc_exceptions.CommandFailed:
                 iocage_lib.ioc_common.logit({
                     "level": "EXCEPTION",
@@ -689,11 +682,10 @@ class IOCCreate(object):
             with iocage_lib.ioc_exec.IOCExec(
                 cmd, jail_uuid, location, plugin=self.plugin, su_env=pkg_env
             ) as _exec:
-                pkg_stdout = _exec.exec_jail()
                 iocage_lib.ioc_common.consume_and_log(
-                     pkg_stdout,
+                     _exec,
                      callback=self.callback,
-                     silent=self.silent
+                     log=not(self.silent)
                 )
         except iocage_lib.ioc_exceptions.CommandFailed as e:
             iocage_lib.ioc_stop.IOCStop(jail_uuid, location, config,
@@ -735,11 +727,10 @@ class IOCCreate(object):
                         cmd, jail_uuid, location, plugin=self.plugin,
                         su_env=pkg_env
                     ) as _exec:
-                        pkg_stdout = _exec.exec_jail()
                         iocage_lib.ioc_common.consume_and_log(
-                            pkg_stdout,
+                            _exec,
                             callback=self.callback,
-                            silent=self.silent
+                            log=not(self.silent)
                         )
                 except iocage_lib.ioc_exceptions.CommandFailed as e:
                     pkg_stderr = e.message[-1].decode().rstrip()

--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -744,7 +744,7 @@ class IOCCreate(object):
                             silent=self.silent,
                             _callback=self.callback)
                 except iocage_lib.ioc_exceptions.CommandFailed as e:
-                    pkg_stderr = e.message.decode().rstrip()
+                    pkg_stderr = e.message[-1].decode().rstrip()
                     pkg_err = True
 
                 if not pkg_err:

--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -37,8 +37,10 @@ import iocage_lib.ioc_json
 import iocage_lib.ioc_list
 import iocage_lib.ioc_start
 import iocage_lib.ioc_stop
+import iocage_lib.ioc_exceptions
 import libzfs
 import itertools
+import dns.resolver
 
 
 class IOCCreate(object):
@@ -547,54 +549,6 @@ class IOCCreate(object):
             if r and len(r.groups()) >= 3:
                 repo = r.group(3)
 
-        # Connectivity test courtesy David Cottlehuber off Google Group
-        # TODO: Use python's dns.resolver here?
-        srv_connect_cmd = ["drill", "-t", f"_http._tcp.{repo} SRV"]
-        dnssec_connect_cmd = ["drill", "-D", f"{repo}"]
-        dns_connect_cmd = ["drill", f"{repo}"]
-
-        iocage_lib.ioc_common.logit({
-            "level": "INFO",
-            "message": f"\nTesting SRV response to {site}"
-        },
-            _callback=self.callback,
-            silent=False)
-
-        # msg_err_return is set to silence stderr, we tell them user that
-        # error before
-        _, _, srv_err = iocage_lib.ioc_exec.IOCExec(
-            srv_connect_cmd, jail_uuid, location, plugin=self.plugin,
-            silent=True, msg_err_return=True).exec_jail()
-
-        if srv_err:
-            # This shouldn't be fatal since SRV records are not required
-            iocage_lib.ioc_common.logit({
-                "level": "WARNING",
-                "message":
-                    f"{repo}'s SRV record could not be verified.\n"
-            },
-                _callback=self.callback,
-                silent=False)
-
-        iocage_lib.ioc_common.logit({
-            "level": "INFO",
-            "message": f"Testing DNSSEC response to {site}"
-        },
-            _callback=self.callback,
-            silent=False)
-        _, _, dnssec_err = iocage_lib.ioc_exec.IOCExec(
-            dnssec_connect_cmd, jail_uuid, location, plugin=self.plugin,
-            silent=True, msg_err_return=True).exec_jail()
-
-        if dnssec_err:
-            # Not fatal, they may not be using DNSSEC
-            iocage_lib.ioc_common.logit({
-                "level": "WARNING",
-                "message": f"{repo} could not be reached via DNSSEC.\n"
-            },
-                _callback=self.callback,
-                silent=False)
-
             iocage_lib.ioc_common.logit({
                 "level": "INFO",
                 "message": f"Testing DNS response to {site}"
@@ -602,11 +556,9 @@ class IOCCreate(object):
                 _callback=self.callback,
                 silent=False)
 
-            _, _, dns_err = iocage_lib.ioc_exec.IOCExec(
-                dns_connect_cmd, jail_uuid, location, plugin=self.plugin,
-                silent=True, msg_err_return=True).exec_jail()
-
-            if dns_err:
+            try:
+                dns.resolver.query(repo)
+            except dns.resolver.NoNameservers:
                 iocage_lib.ioc_common.logit({
                     "level": "EXCEPTION",
                     "message": f"{repo} could not be reached via DNS, check"
@@ -661,16 +613,25 @@ class IOCCreate(object):
         # We will have mismatched ABI errors from earlier, this is to be safe.
         pkg_env = {"ASSUME_ALWAYS_YES": "yes"}
         cmd = ("/usr/local/sbin/pkg-static", "upgrade", "-f", "-q", "-y")
-        pkg_upgrade, pkgup_stderr, pkgup_err = iocage_lib.ioc_exec.IOCExec(
-            cmd, jail_uuid, location, plugin=self.plugin,
-            msg_err_return=True, su_env=pkg_env).exec_jail()
+        try:
+            pkg_stdout = iocage_lib.ioc_exec.IOCExec(
+                cmd, jail_uuid, location, plugin=self.plugin,
+                msg_err_return=True, su_env=pkg_env).exec_jail()
 
-        if pkgup_err:
+            for line in pkg_stdout:
+                iocage_lib.ioc_common.logit(
+                    {
+                        "level": 'INFO',
+                        "message": line.decode().rstrip()
+                    },
+                    silent=self.silent,
+                    _callback=self.callback)
+        except iocage_lib.ioc_exceptions.CommandFailed as e:
             iocage_lib.ioc_stop.IOCStop(jail_uuid, location, config,
                                         force=True, silent=True)
             iocage_lib.ioc_common.logit({
                 "level": "EXCEPTION",
-                "message": pkgup_stderr.decode().rstrip()
+                "message": e.message.decode().rstrip()
             },
                 _callback=self.callback)
 
@@ -700,10 +661,23 @@ class IOCCreate(object):
             while True:
                 cmd = ("/usr/local/sbin/pkg", "install", "-q", "-y", pkg)
 
-                pkg_stdout, pkg_stderr, pkg_err = iocage_lib.ioc_exec.IOCExec(
-                    cmd, jail_uuid, location, plugin=self.plugin,
-                    silent=self.silent, msg_err_return=True,
-                    su_env=pkg_env).exec_jail()
+                try:
+                    pkg_stdout = iocage_lib.ioc_exec.IOCExec(
+                        cmd, jail_uuid, location, plugin=self.plugin,
+                        silent=self.silent, msg_return=True,
+                        su_env=pkg_env).exec_jail()
+
+                    for line in pkg_stdout:
+                        iocage_lib.ioc_common.logit(
+                            {
+                                "level": 'INFO',
+                                "message": line.decode().rstrip()
+                            },
+                            silent=self.silent,
+                            _callback=self.callback)
+                except iocage_lib.ioc_exceptions.CommandFailed as e:
+                    pkg_stderr = e.message.decode().rstrip()
+                    pkg_err = True
 
                 if not pkg_err:
                     break
@@ -721,11 +695,10 @@ class IOCCreate(object):
                 if pkg_retry <= 2:
                     pkg_retry += 1
                 elif pkg_retry == 3 and not self.plugin:
-                    pkg_err_output = pkg_stderr.decode().rstrip()
                     iocage_lib.ioc_common.logit(
                         {
                             "level": "ERROR",
-                            "message": pkg_err_output
+                            "message": pkg_stderr
                         },
                         _callback=self.callback)
                     break

--- a/iocage_lib/ioc_exceptions.py
+++ b/iocage_lib/ioc_exceptions.py
@@ -22,6 +22,7 @@
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 """Exception classes for iocage"""
+import collections
 
 
 class PoolNotActivated(Exception):
@@ -33,6 +34,10 @@ class JailRunning(Exception):
 
 
 class CommandFailed(Exception):
+    """message attribute will be an iterable if a message is supplied"""
     def __init__(self, message):
+        if not isinstance(message, collections.Iterable):
+            message = [message]
+
         self.message = message
         super().__init__(message)

--- a/iocage_lib/ioc_exceptions.py
+++ b/iocage_lib/ioc_exceptions.py
@@ -27,5 +27,12 @@
 class PoolNotActivated(Exception):
     pass
 
+
 class JailRunning(Exception):
     pass
+
+
+class CommandFailed(Exception):
+    def __init__(self, message):
+        self.message = message
+        super().__init__(message)

--- a/iocage_lib/ioc_exec.py
+++ b/iocage_lib/ioc_exec.py
@@ -28,6 +28,7 @@ import iocage_lib.ioc_common
 import iocage_lib.ioc_json
 import iocage_lib.ioc_list
 import iocage_lib.ioc_start
+import iocage_lib.ioc_exceptions
 import select
 import fcntl
 import os
@@ -53,14 +54,13 @@ class IOCExec(object):
                  su_env=None,
                  callback=None):
         self.command = command
-        self.uuid = uuid.replace(".", "_")
+        self.uuid = uuid.replace(".", "_") if uuid is not None else uuid
         self.path = path
         self.host_user = host_user
         self.jail_user = jail_user
         self.plugin = plugin
         self.pkg = pkg
         self.skip = skip
-        self.console = console
         self.silent = silent
         self.msg_return = msg_return
         self.msg_err_return = msg_err_return
@@ -83,136 +83,173 @@ class IOCExec(object):
             flag = "-u"
             user = self.host_user
 
-        status, _ = iocage_lib.ioc_list.IOCList().list_get_jid(self.uuid)
-        conf = iocage_lib.ioc_json.IOCJson(self.path).json_load()
-        exec_fib = conf["exec_fib"]
+        if self.uuid is not None:
+            status, _ = iocage_lib.ioc_list.IOCList().list_get_jid(self.uuid)
+            conf = iocage_lib.ioc_json.IOCJson(self.path).json_load()
+            exec_fib = conf["exec_fib"]
 
-        if not status:
-            if not self.plugin and not self.skip:
+            if not status:
+                if not self.plugin and not self.skip:
+                    iocage_lib.ioc_common.logit(
+                        {
+                            "level": "INFO",
+                            "message": f"{self.uuid} is not running,"
+                            " starting jail"
+                        },
+                        _callback=self.callback,
+                        silent=self.silent)
+
+                if conf["type"] in ("jail", "plugin", "pluginv2", "clonejail"):
+                    iocage_lib.ioc_start.IOCStart(
+                        self.uuid, self.path, conf, silent=True)
+                elif conf["type"] == "basejail":
+                    iocage_lib.ioc_common.logit(
+                        {
+                            "level":
+                            "EXCEPTION",
+                            "message":
+                            "Please run \"iocage migrate\" before trying"
+                            f" to start {self.uuid}"
+                        },
+                        _callback=self.callback,
+                        silent=self.silent)
+                elif conf["type"] == "template":
+                    iocage_lib.ioc_common.logit(
+                        {
+                            "level":
+                            "EXCEPTION",
+                            "message":
+                            "Please convert back to a jail before trying"
+                            f" to start {self.uuid}"
+                        },
+                        _callback=self.callback,
+                        silent=self.silent)
+                else:
+                    iocage_lib.ioc_common.logit(
+                        {
+                            "level":
+                            "EXCEPTION",
+                            "message":
+                            f"{conf['type']} is not a supported jail"
+                            " type."
+                        },
+                        _callback=self.callback,
+                        silent=self.silent)
+
                 iocage_lib.ioc_common.logit(
                     {
                         "level": "INFO",
-                        "message": f"{self.uuid} is not running, starting jail"
+                        "message": "\nCommand output:"
                     },
                     _callback=self.callback,
                     silent=self.silent)
 
-            if conf["type"] in ("jail", "plugin", "pluginv2", "clonejail"):
-                iocage_lib.ioc_start.IOCStart(
-                    self.uuid, self.path, conf, silent=True)
-            elif conf["type"] == "basejail":
-                iocage_lib.ioc_common.logit(
-                    {
-                        "level":
-                        "EXCEPTION",
-                        "message":
-                        "Please run \"iocage migrate\" before trying"
-                        f" to start {self.uuid}"
-                    },
-                    _callback=self.callback,
-                    silent=self.silent)
-            elif conf["type"] == "template":
-                iocage_lib.ioc_common.logit(
-                    {
-                        "level":
-                        "EXCEPTION",
-                        "message":
-                        "Please convert back to a jail before trying"
-                        f" to start {self.uuid}"
-                    },
-                    _callback=self.callback,
-                    silent=self.silent)
+        try:
+            if not self.pkg:
+                cmd = [
+                    "/usr/sbin/setfib", exec_fib, "jexec", flag, user,
+                    f"ioc-{self.uuid}"
+                ] + list(self.command)
             else:
-                iocage_lib.ioc_common.logit(
-                    {
-                        "level":
-                        "EXCEPTION",
-                        "message":
-                        f"{conf['type']} is not a supported jail"
-                        " type."
-                    },
-                    _callback=self.callback,
-                    silent=self.silent)
+                cmd = self.command
 
-            iocage_lib.ioc_common.logit(
-                {
-                    "level": "INFO",
-                    "message": "\nCommand output:"
-                },
-                _callback=self.callback,
-                silent=self.silent)
+            if self.msg_return or self.msg_err_return:
+                p = su.Popen(cmd, stdout=su.PIPE, stderr=su.PIPE,
+                             close_fds=True, bufsize=0, env=self.su_env)
 
-        if self.console:
-            login_flags = conf["login_flags"].split()
-            su.Popen([
-                "/usr/sbin/setfib", exec_fib, "jexec", f"ioc-{self.uuid}",
-                "login"] + login_flags, env=self.su_env).communicate()
+                # Courtesy of @william-gr
+                # service(8) and some rc.d scripts have the bad habit of
+                # exec'ing and never closing stdout/stderr. This makes
+                # sure we read only enough until the command exits and do
+                # not wait on the pipe to close on the other end.
+                #
+                # Same issue can be demonstrated with:
+                # $ jexec 1 service postgresql onerestart | cat
+                # ... <hangs>
+                # postgresql rc.d command never closes the pipe
+                rtrn_stdout = b''
+                rtrn_stderr = b''
+                for i in ('stdout', 'stderr'):
+                    fileno = getattr(p, i).fileno()
+                    fl = fcntl.fcntl(fileno, fcntl.F_GETFL)
+                    fcntl.fcntl(fileno, fcntl.F_SETFL, fl | os.O_NONBLOCK)
 
-            return None, False
-        else:
-            try:
-                if not self.pkg:
-                    cmd = [
-                        "/usr/sbin/setfib", exec_fib, "jexec", flag, user,
-                        f"ioc-{self.uuid}"
-                    ] + list(self.command)
-                else:
-                    cmd = self.command
+                timeout = 0.1
+                yield_stdout_now = False
+                yield_stderr_now = False
 
-                if self.msg_return or self.msg_err_return:
-                    p = su.Popen(cmd, stdout=su.PIPE, stderr=su.PIPE,
-                                 close_fds=True, bufsize=0, env=self.su_env)
+                while True:
+                    r = select.select([
+                        p.stdout.fileno(),
+                        p.stderr.fileno()], [], [], timeout)[0]
 
-                    # Courtesy of @william-gr
-                    # service(8) and some rc.d scripts have the bad habit of
-                    # exec'ing and never closing stdout/stderr. This makes
-                    # sure we read only enough until the command exits and do
-                    # not wait on the pipe to close on the other end.
-                    #
-                    # Same issue can be demonstrated with:
-                    # $ jexec 1 service postgresql onerestart | cat
-                    # ... <hangs>
-                    # postgresql rc.d command never closes the pipe
-                    rtrn_stdout = b''
-                    rtrn_stderr = b''
-                    for i in ('stdout', 'stderr'):
-                        fileno = getattr(p, i).fileno()
-                        fl = fcntl.fcntl(fileno, fcntl.F_GETFL)
-                        fcntl.fcntl(fileno, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+                    if p.poll() is not None:
+                        if timeout == 0:
+                            break
+                        else:
+                            timeout = 0
 
-                    timeout = 0.1
-                    while True:
-                        r = select.select([p.stdout.fileno(),
-                                           p.stderr.fileno()], [], [], timeout)[0]
-                        if r:
-                            if p.stdout.fileno() in r:
-                                rtrn_stdout += p.stdout.read()
-                            if p.stderr.fileno() in r:
-                                rtrn_stderr += p.stderr.read()
+                    if r:
+                        if p.stdout.fileno() in r:
+                            if rtrn_stdout.endswith(b'\n'):
+                                yield_stdout_now = True
 
-                        if p.poll() is not None:
-                            if timeout == 0:
-                                break
-                            else:
-                                timeout = 0
+                            if not yield_stdout_now:
+                                stdout = p.stdout.read()
+                                rtrn_stdout += stdout
 
-                    p.stdout.close()
-                    p.stderr.close()
+                                if rtrn_stdout.endswith(b'\n'):
+                                    yield_stdout_now = True
 
-                    error = True if p.returncode != 0 else False
+                        if p.stderr.fileno() in r:
+                            if rtrn_stderr.endswith(b'\n'):
+                                yield_stderr_now = True
 
-                    if self.msg_err_return:
-                        return rtrn_stdout, rtrn_stderr, error
+                            if not yield_stderr_now:
+                                stderr = p.stderr.read()
+                                rtrn_stderr += stderr
 
-                    return rtrn_stdout, error
-                else:
-                    stdout = None if not self.silent else su.DEVNULL
-                    stderr = None if not self.silent else su.DEVNULL
+                                if rtrn_stderr.endswith(b'\n'):
+                                    yield_stderr_now = True
 
-                    p = su.Popen(
-                        cmd, stdout=stdout, stderr=stderr, env=self.su_env
-                    ).communicate()
+                        if self.msg_err_return:
+                            if yield_stdout_now and yield_stderr_now:
+                                yield_stdout_now = yield_stderr_now = False
+                                _rtrn_stdout = rtrn_stdout
+                                _rtrn_stderr = rtrn_stderr
 
-                    return "", False
-            except su.CalledProcessError as err:
-                return err.output.decode("utf-8").rstrip(), True
+                                # Set up a new line
+                                rtrn_stdout = rtrn_stderr = b''
+
+                                yield _rtrn_stdout, _rtrn_stderr
+                        else:
+                            if yield_stdout_now:
+                                yield_stdout_now = False
+                                _rtrn_stdout = rtrn_stdout
+
+                                # Set up a new line
+                                rtrn_stdout = b''
+
+                                yield _rtrn_stdout
+
+                p.stdout.close()
+                p.stderr.close()
+
+                error = True if p.returncode != 0 else False
+
+                if error and self.uuid is not None:
+                    # self.uuid being None means a release being updated,
+                    # We will get false positives for EOL notices
+                    raise iocage_lib.ioc_exceptions.CommandFailed(
+                        rtrn_stderr)
+            else:
+                stdout = None if not self.silent else su.DEVNULL
+                stderr = None if not self.silent else su.DEVNULL
+
+                p = su.Popen(
+                    cmd, stdout=stdout, stderr=stderr, env=self.su_env
+                ).communicate()
+
+                return "", False
+        except su.CalledProcessError as err:
+            return err.output.decode("utf-8").rstrip(), True

--- a/iocage_lib/ioc_exec.py
+++ b/iocage_lib/ioc_exec.py
@@ -96,9 +96,17 @@ class IOCExec(object):
             self.cmd, stdout=su.PIPE, stderr=su.PIPE, close_fds=True,
             bufsize=0, env=self.su_env
         )
-        return self
+        self.exec_gen = self.exec_jail()
+
+        return self.exec_gen
 
     def __exit__(self, *args):
+        try:
+            for i in self.exec_gen:
+                continue
+        except StopIteration:
+            pass
+
         try:
             self.proc.wait(timeout=15)
         except su.TimeoutExpired:
@@ -216,3 +224,9 @@ class IOCExec(object):
             if error:
                 raise iocage_lib.ioc_exceptions.CommandFailed(
                     list(stderr_queue))
+
+
+class SilentExec(object):
+    def __init__(self, *args, **kwargs):
+        with IOCExec(*args, **kwargs) as silent:  # noqa
+            pass

--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -880,47 +880,34 @@ class IOCFetch(object):
                 f"{mount_root}/etc/freebsd-update.conf",
                 "--not-running-from-cron", "fetch"
             ]
-
-            stdout = iocage_lib.ioc_exec.IOCExec(
+            with iocage_lib.ioc_exec.IOCExec(
                 fetch_cmd,
                 uuid,
                 f"{self.iocroot}/jails/{uuid}",
                 pkg=True,
-                msg_return=True,
                 callback=self.callback,
                 su_env=fetch_env
-            ).exec_jail()
-
-            for line in stdout:
-                iocage_lib.ioc_common.logit({
-                    "level": "INFO",
-                    "message": line.decode().rstrip()
-                },
-                    _callback=self.callback,
-                    silent=self.silent)
+            ) as _exec:
+                stdout = _exec.exec_jail()
+                iocage_lib.ioc_common.consume_and_log(
+                    stdout, callback=self.callback)
 
             fetch_install_cmd = [
                     fetch_name, "-b", mount_root, "-d",
                     f"{mount_root}/var/db/freebsd-update/", "-f",
                     f"{mount_root}/etc/freebsd-update.conf", "install"
             ]
-            stdout = iocage_lib.ioc_exec.IOCExec(
+            with iocage_lib.ioc_exec.IOCExec(
                 fetch_install_cmd,
                 uuid,
                 f"{self.iocroot}/jails/{uuid}",
                 pkg=True,
-                msg_return=True,
                 callback=self.callback,
                 su_env=fetch_env
-            ).exec_jail()
-
-            for line in stdout:
-                iocage_lib.ioc_common.logit({
-                    "level": "INFO",
-                    "message": line.decode().rstrip()
-                },
-                    _callback=self.callback,
-                    silent=self.silent)
+            ) as _exec:
+                stdout = _exec.exec_jail()
+                iocage_lib.ioc_common.consume_and_log(
+                    stdout, callback=self.callback)
 
             if self.verify:
                 # tmp only exists if they verify SSL certs

--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -888,9 +888,8 @@ class IOCFetch(object):
                 callback=self.callback,
                 su_env=fetch_env
             ) as _exec:
-                stdout = _exec.exec_jail()
                 iocage_lib.ioc_common.consume_and_log(
-                    stdout, callback=self.callback)
+                    _exec, callback=self.callback)
 
             fetch_install_cmd = [
                     fetch_name, "-b", mount_root, "-d",
@@ -905,9 +904,8 @@ class IOCFetch(object):
                 callback=self.callback,
                 su_env=fetch_env
             ) as _exec:
-                stdout = _exec.exec_jail()
                 iocage_lib.ioc_common.consume_and_log(
-                    stdout, callback=self.callback)
+                    _exec, callback=self.callback)
 
             if self.verify:
                 # tmp only exists if they verify SSL certs

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -1392,10 +1392,9 @@ class IOCJson(object):
                         _path,
                         plugin=True
                     ) as _exec:
-                        out = _exec.exec_jail()
                         prop_out = iocage_lib.ioc_common.consume_and_log(
-                            out,
-                            return_list=True
+                            _exec,
+                            log=False
                         )
                         return prop_out[0]
             else:
@@ -1467,15 +1466,9 @@ class IOCJson(object):
                     },
                     _callback=self.callback,
                     silent=self.silent)
-            with iocage_lib.ioc_exec.IOCExec(
+            iocage_lib.ioc_exec.SilentExec(
                 prop_cmd, uuid, _path
-            ) as _exec:
-                output = _exec.exec_jail()
-                iocage_lib.ioc_common.consume_and_log(
-                    output,
-                    callback=self.callback,
-                    silent=True
-                )
+            )
 
             if restart:
                 iocage_lib.ioc_common.logit(
@@ -1492,17 +1485,11 @@ class IOCJson(object):
                     },
                     _callback=self.callback,
                     silent=self.silent)
-                with iocage_lib.ioc_exec.IOCExec(
+                iocage_lib.ioc_exec.SilentExec(
                     servicerestart,
                     uuid,
                     _path
-                ) as _exec:
-                    output = _exec.exec_jail()
-                    iocage_lib.ioc_common.consume_and_log(
-                        output,
-                        callback=self.callback,
-                        silent=True
-                    )
+                )
 
             iocage_lib.ioc_common.logit(
                 {

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -1466,9 +1466,13 @@ class IOCJson(object):
                     },
                     _callback=self.callback,
                     silent=self.silent)
-            iocage_lib.ioc_exec.SilentExec(
+            with iocage_lib.ioc_exec.IOCExec(
                 prop_cmd, uuid, _path
-            )
+            ) as _exec:
+                iocage_lib.ioc_common.consume_and_log(
+                    _exec,
+                    callback=self.callback
+                )
 
             if restart:
                 iocage_lib.ioc_common.logit(
@@ -1485,11 +1489,15 @@ class IOCJson(object):
                     },
                     _callback=self.callback,
                     silent=self.silent)
-                iocage_lib.ioc_exec.SilentExec(
+                with iocage_lib.ioc_exec.IOCExec(
                     servicerestart,
                     uuid,
                     _path
-                )
+                ) as _exec:
+                    iocage_lib.ioc_common.consume_and_log(
+                        _exec,
+                        callback=self.callback
+                    )
 
             iocage_lib.ioc_common.logit(
                 {

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -1386,13 +1386,18 @@ class IOCJson(object):
                 if len(_prop) > 1:
                     return iocage_lib.ioc_common.get_nested_key(settings, prop)
                 else:
-                    return iocage_lib.ioc_exec.IOCExec(
+                    with iocage_lib.ioc_exec.IOCExec(
                         prop_cmd,
                         uuid,
                         _path,
-                        plugin=True,
-                        msg_return=True,
-                        silent=True).exec_jail()
+                        plugin=True
+                    ) as _exec:
+                        out = _exec.exec_jail()
+                        prop_out = iocage_lib.ioc_common.consume_and_log(
+                            out,
+                            return_list=True
+                        )
+                        return prop_out[0]
             else:
                 return settings
         except KeyError:
@@ -1462,8 +1467,15 @@ class IOCJson(object):
                     },
                     _callback=self.callback,
                     silent=self.silent)
-            iocage_lib.ioc_exec.IOCExec(
-                prop_cmd, uuid, _path).exec_jail()
+            with iocage_lib.ioc_exec.IOCExec(
+                prop_cmd, uuid, _path
+            ) as _exec:
+                output = _exec.exec_jail()
+                iocage_lib.ioc_common.consume_and_log(
+                    output,
+                    callback=self.callback,
+                    silent=True
+                )
 
             if restart:
                 iocage_lib.ioc_common.logit(
@@ -1480,10 +1492,17 @@ class IOCJson(object):
                     },
                     _callback=self.callback,
                     silent=self.silent)
-                iocage_lib.ioc_exec.IOCExec(
+                with iocage_lib.ioc_exec.IOCExec(
                     servicerestart,
                     uuid,
-                    _path).exec_jail()
+                    _path
+                ) as _exec:
+                    output = _exec.exec_jail()
+                    iocage_lib.ioc_common.consume_and_log(
+                        output,
+                        callback=self.callback,
+                        silent=True
+                    )
 
             iocage_lib.ioc_common.logit(
                 {

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -603,7 +603,7 @@ fingerprint: {fingerprint}
                     iocage_lib.ioc_common.logit(
                         {
                             "level": "EXCEPTION",
-                            "message": e.message.decode().rstrip()
+                            "message": e.message[-1].decode().rstrip()
                         }, _callback=self.callback)
 
                 ui_json = f"{jaildir}/plugin/ui.json"

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -592,9 +592,8 @@ fingerprint: {fingerprint}
                         skip=True, callback=self.callback,
                         su_env=plugin_env
                     ) as _exec:
-                        msg = _exec.exec_jail()
                         iocage_lib.ioc_common.consume_and_log(
-                            msg,
+                            _exec,
                             callback=self.callback
                         )
                 except iocage_lib.ioc_exceptions.CommandFailed as e:
@@ -932,11 +931,10 @@ fingerprint: {fingerprint}
                 path=f"{self.iocroot}/jails/{self.plugin}",
                 callback=self.callback
             ) as _exec:
-                output = _exec.exec_jail()
                 iocage_lib.ioc_common.consume_and_log(
-                    output,
+                    _exec,
                     callback=self.callback,
-                    silent=self.silent
+                    log=not(self.silent)
                 )
         except iocage_lib.ioc_exceptions.CommandFailed as e:
             self.__rollback_jail__(name="update")
@@ -1162,11 +1160,10 @@ fingerprint: {fingerprint}
                 skip=True,
                 callback=self.callback
             ) as _exec:
-                output = _exec.exec_jail()
                 iocage_lib.ioc_common.consume_and_log(
-                    output,
+                    _exec,
                     callback=self.callback,
-                    silent=self.silent
+                    log=not(self.silent)
                 )
         except iocage_lib.ioc_exceptions.CommandFailed as e:
             final_msg = 'An error occurred! Please read above'
@@ -1200,32 +1197,20 @@ fingerprint: {fingerprint}
                 snap.delete()
 
     def __stop_rc__(self):
-        with iocage_lib.ioc_exec.IOCExec(
+        iocage_lib.ioc_exec.SilentExec(
             command=["/bin/sh", "/etc/rc.shutdown"],
             uuid=self.plugin,
             path=f"{self.iocroot}/jails/{self.plugin}",
             callback=self.callback
-        ) as _exec:
-            output = _exec.exec_jail()
-            iocage_lib.ioc_common.consume_and_log(
-                output,
-                callback=self.callback,
-                silent=True
-            )
+        )
 
     def __start_rc__(self):
-        with iocage_lib.ioc_exec.IOCExec(
+        iocage_lib.ioc_exec.SilentExec(
             command=["/bin/sh", "/etc/rc"],
             uuid=self.plugin,
             path=f"{self.iocroot}/jails/{self.plugin}",
             callback=self.callback
-        ) as _exec:
-            output = _exec.exec_jail()
-            iocage_lib.ioc_common.consume_and_log(
-                output,
-                callback=self.callback,
-                silent=True
-            )
+        )
 
     def __check_manifest__(self, plugin_conf):
         """If the Major ABI changed, they cannot update anymore."""

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -847,10 +847,8 @@ class IOCage(object):
                 pkg=pkg,
                 su_env=su_env
             ) as _exec:
-                msg = _exec.exec_jail()
                 msgs = ioc_common.consume_and_log(
-                    msg,
-                    return_list=True
+                    _exec
                 )
 
                 if msg_return:

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -815,6 +815,7 @@ class IOCage(object):
                 "login"] + login_flags
 
             su.Popen(console_cmd, env=su_env).communicate()
+            return
 
         try:
             msg = ioc_exec.IOCExec(

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
     install_requires=[
         'dulwich>=0.18.6',
         'netifaces>=0.10.6',
+        'dnspython>=1.15.0',
         'libzfs'
     ],
     setup_requires=['pytest-runner'],


### PR DESCRIPTION
iocage side of #37742, still requires plugin work in freenas/freenas.

Use python dns.resolver
Drop other types of DNS tests
Make Exec a generator
New Exception type CommandFailed for Exec failures
Use Exec for RELEASE updating along with jail
Break console out of Exec
Log update progress now (means colors as well)

Ticket: #37742