### PR TITLE
Delete jails for all exceptions in case of jail failure by default

### DIFF
--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -167,7 +167,7 @@ class IOCPlugin(object):
             self.__fetch_plugin_install_packages__(jail_name, jaildir, conf,
                                                    _conf, pkg, props, repo_dir)
             self.__fetch_plugin_post_install__(conf, _conf, jaildir, jail_name)
-        except (KeyboardInterrupt, SystemExit, RuntimeError) as e:
+        except Exception as e:
             if not self.keep_jail_on_failure:
                 iocage_lib.ioc_destroy.IOCDestroy().destroy_jail(location)
                 iocage_lib.ioc_common.logit({


### PR DESCRIPTION
This commit makes sure that jails are deleted by default in all exceptions that occur.
Ticket: #50519