### PR TITLE
STABLE: Skip RELEASE checking for EMPTY jails

### DIFF
--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -906,6 +906,8 @@ class IOCJson(object):
             if release[:4].endswith("-"):
                 # 9.3-RELEASE and under don't actually have this binary.
                 release = conf["release"]
+            elif release == 'EMPTY':
+                pass
             else:
                 try:
                     with open(freebsd_version, "r") as r:
@@ -919,7 +921,7 @@ class IOCJson(object):
                             'level': 'EXCEPTION',
                             'message': 'Exception:'
                             f' "{e.__class__.__name__}:{str(e)}" occured\n'
-                            "Loading {uuid}'s configuration failed"
+                            f"Loading {uuid}'s configuration failed"
                         }
                     )
 


### PR DESCRIPTION
During configuration upgrade, this will cause real headaches.

FreeNAS Ticket: #52637