### PR TITLE
Raise proper exception for old invalid Mac addresses

### DIFF
--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -888,7 +888,13 @@ class IOCStart(object):
             mac_a, mac_b = self.__generate_mac_address_pair(nic)
             self.set(f"{nic}_mac={mac_a} {mac_b}")
         else:
-            mac_a, mac_b = mac.replace(',', ' ').split()
+            try:
+                mac_a, mac_b = mac.replace(',', ' ').split()
+            except Exception as e:
+                iocage_lib.ioc_common.logit({
+                    "level": "EXCEPTION",
+                    "message": f'Please correct mac addresses format for {nic}'
+                })
 
         return mac_a, mac_b
 


### PR DESCRIPTION
This commit makes sure that we raise exception via proper iocage channels incase an old invalid mac address entry exists in the system.
Ticket: #53674
