### PR TITLE
Add TERM to default clean envs

### DIFF
--- a/iocage_lib/ioc_exec.py
+++ b/iocage_lib/ioc_exec.py
@@ -67,6 +67,7 @@ class IOCExec(object):
         su_env.setdefault('PATH', path)
         su_env.setdefault('PWD', '/')
         su_env.setdefault('HOME', '/')
+        su_env.setdefault('TERM', 'xterm-256color')
 
         self.su_env = su_env
         self.callback = callback

--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -857,7 +857,8 @@ class IOCFetch(object):
             'PAGER': '/bin/cat',
             'PATH': path,
             'PWD': '/',
-            'HOME': '/'
+            'HOME': '/',
+            'TERM': 'xterm-256color'
             }
 
         if os.path.isfile(f"{mount_root}/etc/freebsd-update.conf"):

--- a/iocage_lib/ioc_upgrade.py
+++ b/iocage_lib/ioc_upgrade.py
@@ -73,7 +73,8 @@ class IOCUpgrade(object):
             'PAGER': '/bin/cat',
             'PATH': path,
             'PWD': '/',
-            'HOME': '/'
+            'HOME': '/',
+            'TERM': 'xterm-256color'
             }
 
         self.callback = callback

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -774,7 +774,14 @@ class IOCage(object):
         exec_clean = self.get('exec_clean')
 
         if exec_clean == '1':
-            su_env = None
+            env_path = '/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:'\
+                   '/usr/local/bin:/root/bin'
+            su_env = {
+                'PATH': env_path,
+                'PWD': '/',
+                'HOME': '/',
+                'TERM': 'xterm-256color'
+                }
         else:
             su_env = os.environ.copy()
 


### PR DESCRIPTION
In addition we also no longer set None for a clean env on exec/console. Not setting TERM resulted in some odd entries like su or screen that don't always play nice with utilities inside the jail.

FreeNAS Ticket: #52237