### PR TITLE
Continue on corrupt jail configurations

### DIFF
--- a/iocage_lib/ioc_exceptions.py
+++ b/iocage_lib/ioc_exceptions.py
@@ -41,3 +41,21 @@ class CommandFailed(Exception):
 
         self.message = message
         super().__init__(message)
+
+
+class JailMisconfigured(Exception):
+    """message attribute will be a string if a message is supplied"""
+    def __init__(self, message):
+        if not isinstance(message, str):
+            message = str(message)
+
+        self.message = message
+        super().__init__(message)
+
+
+class JailCorruptConfiguration(JailMisconfigured):
+    pass
+
+
+class JailMissingConfiguration(JailMisconfigured):
+    pass

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -237,6 +237,16 @@ class IOCJson(object):
         try:
             with open(self.location + "/config.json", "r") as conf:
                 conf = json.load(conf)
+        except json.decoder.JSONDecodeError:
+                iocage_lib.ioc_common.logit(
+                    {
+                        'level': 'EXCEPTION',
+                        'message': f'{jail_uuid} has a corrupt configuration,'
+                        ' please fix this jail or destroy and recreate it.'
+                    },
+                    _callback=self.callback,
+                    silent=self.silent,
+                    exception=ioc_exceptions.JailCorruptConfiguration)
         except FileNotFoundError:
             try:
                 # If this is a legacy jail, it will be missing this file but
@@ -256,7 +266,8 @@ class IOCJson(object):
                             " please destroy this jail and recreate it."
                         },
                         _callback=self.callback,
-                        silent=self.silent)
+                        silent=self.silent,
+                        exception=ioc_exceptions.JailMissingConfiguration)
 
             if not self.force:
                 iocage_lib.ioc_common.logit(

--- a/iocage_lib/ioc_list.py
+++ b/iocage_lib/ioc_list.py
@@ -160,6 +160,7 @@ class IOCList(object):
             mountpoint = jail.properties["mountpoint"].value
             try:
                 conf = iocage_lib.ioc_json.IOCJson(mountpoint).json_load()
+                state = ''
             except (Exception, SystemExit):
                 # Jail is corrupt, we want all the keys to exist.
                 # So we will take the defaults and let the user
@@ -173,8 +174,10 @@ class IOCList(object):
                     for x in def_props
                 }
                 conf['host_hostuuid'] = \
-                    f'{jail.name.split("/")[-1]} - CORRUPTED'
+                    f'{jail.name.split("/")[-1]}'
                 conf['release'] = 'N/A'
+                state = 'CORRUPT'
+                jid = '-'
 
             uuid_full = conf["host_hostuuid"]
             uuid = uuid_full
@@ -216,14 +219,14 @@ class IOCList(object):
             if ip6 == "none":
                 ip6 = "-"
 
-            # Jail cannot have spaces, this is to remove the CORRUPTED from
-            # the name
-            status, jid = self.list_get_jid(uuid_full.split()[0])
+            # Will be set already by a corrupt jail
+            if state != 'CORRUPT':
+                status, jid = self.list_get_jid(uuid_full)
 
-            if status:
-                state = "up"
-            else:
-                state = "down"
+                if status:
+                    state = "up"
+                else:
+                    state = "down"
 
             if conf["type"] == "template":
                 template = "-"

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1155,7 +1155,26 @@ class IOCage(object):
                         jail_list.append({uuid: state})
                     elif prop == "all":
                         _props = {}
-                        props = ioc_json.IOCJson(path).json_get_value(prop)
+                        try:
+                            props = ioc_json.IOCJson(path).json_get_value(prop)
+                        except (Exception, SystemExit):
+                            # Jail is corrupt, we want all the keys to exist.
+                            # So we will take the defaults and let the user
+                            # know that they are not correct.
+                            def_props = ioc_json.IOCJson().json_get_value(
+                                'all',
+                                default=True
+                            )
+                            props = {
+                                x: 'N/A'
+                                for x in def_props
+                            }
+                            props['host_hostuuid'] = f'{uuid} - CORRUPTED'
+                            props['state'] = state
+                            props['release'] = 'N/A'
+                            jail_list.append({uuid: props})
+
+                            continue
 
                         # We want this sorted below, so we add it to the old
                         # dict

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1169,8 +1169,8 @@ class IOCage(object):
                                 x: 'N/A'
                                 for x in def_props
                             }
-                            props['host_hostuuid'] = f'{uuid} - CORRUPTED'
-                            props['state'] = state
+                            props['host_hostuuid'] = uuid
+                            props['state'] = 'CORRUPT'
                             props['release'] = 'N/A'
                             jail_list.append({uuid: props})
 


### PR DESCRIPTION
Previous behavior was to immediately die

- Add 3 new exceptions for misconfigured jails
- Start to use them in ioc_json
- Show corrupt jails in iocage list
- Return corrupt jails in get all recursive API with default key values being replaced with N/A (FreeNAS focused)

FreeNAS Ticket: #51997