### PR TITLE
STABLE: Continue on corrupt jail configurations

### DIFF
--- a/iocage_lib/ioc_debug.py
+++ b/iocage_lib/ioc_debug.py
@@ -105,7 +105,14 @@ class IOCDebug(object):
             ['cat', f'{jail_path}/etc/resolv.conf'], jail=name
         )
 
-        self.__write_debug__(all_props, jail_debug_path, 'PROPS', json=True)
+        if all_props['state'] != 'CORRUPT':
+            self.__write_debug__(all_props, jail_debug_path, 'PROPS',
+                                 json=True, method='w')
+        else:
+            lines = [line.rstrip() for line in open(f'{path}/config.json')]
+            self.__write_debug__(lines, jail_debug_path, 'PROPS - CORRUPT',
+                                 method='w')
+
         self.__write_debug__(fstab, jail_debug_path, '\nFSTAB')
         self.__write_debug__(hosts, jail_debug_path, '\n/ETC/HOSTS')
         self.__write_debug__(rc, jail_debug_path, '\n/ETC/RC.CONF')
@@ -143,7 +150,14 @@ class IOCDebug(object):
         _props = {}
         status, jid = ioc_list.IOCList().list_get_jid(name)
         state = 'up' if status else 'down'
-        props = ioc_json.IOCJson(path).json_get_value('all')
+
+        try:
+            props = ioc_json.IOCJson(path).json_get_value('all')
+        except (Exception, SystemExit):
+            # Jail is corrupt, we want all the keys to exist.
+            _props['state'] = 'CORRUPT'
+
+            return _props
 
         # We want this sorted below, so we add it to the old dict
         props['state'] = state

--- a/iocage_lib/ioc_exceptions.py
+++ b/iocage_lib/ioc_exceptions.py
@@ -26,3 +26,35 @@
 
 class PoolNotActivated(Exception):
     pass
+
+
+class JailRunning(Exception):
+    pass
+
+
+class CommandFailed(Exception):
+    """message attribute will be an iterable if a message is supplied"""
+    def __init__(self, message):
+        if not isinstance(message, collections.Iterable):
+            message = [message]
+
+        self.message = message
+        super().__init__(message)
+
+
+class JailMisconfigured(Exception):
+    """message attribute will be a string if a message is supplied"""
+    def __init__(self, message):
+        if not isinstance(message, str):
+            message = str(message)
+
+        self.message = message
+        super().__init__(message)
+
+
+class JailCorruptConfiguration(JailMisconfigured):
+    pass
+
+
+class JailMissingConfiguration(JailMisconfigured):
+    pass

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -237,6 +237,16 @@ class IOCJson(object):
         try:
             with open(self.location + "/config.json", "r") as conf:
                 conf = json.load(conf)
+        except json.decoder.JSONDecodeError:
+                iocage_lib.ioc_common.logit(
+                    {
+                        'level': 'EXCEPTION',
+                        'message': f'{jail_uuid} has a corrupt configuration,'
+                        ' please fix this jail or destroy and recreate it.'
+                    },
+                    _callback=self.callback,
+                    silent=self.silent,
+                    exception=ioc_exceptions.JailCorruptConfiguration)
         except FileNotFoundError:
             try:
                 # If this is a legacy jail, it will be missing this file but
@@ -256,7 +266,8 @@ class IOCJson(object):
                             " please destroy this jail and recreate it."
                         },
                         _callback=self.callback,
-                        silent=self.silent)
+                        silent=self.silent,
+                        exception=ioc_exceptions.JailMissingConfiguration)
 
             if not self.force:
                 iocage_lib.ioc_common.logit(

--- a/iocage_lib/ioc_list.py
+++ b/iocage_lib/ioc_list.py
@@ -160,6 +160,7 @@ class IOCList(object):
             mountpoint = jail.properties["mountpoint"].value
             try:
                 conf = iocage_lib.ioc_json.IOCJson(mountpoint).json_load()
+                state = ''
             except (Exception, SystemExit):
                 # Jail is corrupt, we want all the keys to exist.
                 # So we will take the defaults and let the user
@@ -173,8 +174,10 @@ class IOCList(object):
                     for x in def_props
                 }
                 conf['host_hostuuid'] = \
-                    f'{jail.name.split("/")[-1]} - CORRUPTED'
+                    f'{jail.name.split("/")[-1]}'
                 conf['release'] = 'N/A'
+                state = 'CORRUPT'
+                jid = '-'
 
             uuid_full = conf["host_hostuuid"]
             uuid = uuid_full
@@ -215,14 +218,14 @@ class IOCList(object):
             if ip6 == "none":
                 ip6 = "-"
 
-            # Jail cannot have spaces, this is to remove the CORRUPTED from
-            # the name
-            status, jid = self.list_get_jid(uuid_full.split()[0])
+            # Will be set already by a corrupt jail
+            if state != 'CORRUPT':
+                status, jid = self.list_get_jid(uuid_full)
 
-            if status:
-                state = "up"
-            else:
-                state = "down"
+                if status:
+                    state = "up"
+                else:
+                    state = "down"
 
             if conf["type"] == "template":
                 template = "-"

--- a/iocage_lib/ioc_list.py
+++ b/iocage_lib/ioc_list.py
@@ -119,6 +119,14 @@ class IOCList(object):
                                " it."
                 }, _callback=self.callback,
                     silent=self.silent)
+            except (Exception, SystemExit):
+                # Jail is corrupt, we want the user to know
+                conf = {
+                    'host_hostuuid':
+                        f'{mountpoint.rsplit("/", 1)[-1]} - CORRUPTED',
+                    'ip4_addr': 'N/A',
+                    'dhcp': 'N/A'
+                }
 
             uuid = conf["host_hostuuid"]
             ip4 = conf["ip4_addr"] if conf["dhcp"] != "on" else "DHCP"
@@ -150,7 +158,23 @@ class IOCList(object):
 
         for jail in jails:
             mountpoint = jail.properties["mountpoint"].value
-            conf = iocage_lib.ioc_json.IOCJson(mountpoint).json_load()
+            try:
+                conf = iocage_lib.ioc_json.IOCJson(mountpoint).json_load()
+            except (Exception, SystemExit):
+                # Jail is corrupt, we want all the keys to exist.
+                # So we will take the defaults and let the user
+                # know that they are not correct.
+                def_props = iocage_lib.ioc_json.IOCJson().json_get_value(
+                    'all',
+                    default=True
+                )
+                conf = {
+                    x: 'N/A'
+                    for x in def_props
+                }
+                conf['host_hostuuid'] = \
+                    f'{jail.name.split("/")[-1]} - CORRUPTED'
+                conf['release'] = 'N/A'
 
             uuid_full = conf["host_hostuuid"]
             uuid = uuid_full
@@ -191,7 +215,9 @@ class IOCList(object):
             if ip6 == "none":
                 ip6 = "-"
 
-            status, jid = self.list_get_jid(uuid_full)
+            # Jail cannot have spaces, this is to remove the CORRUPTED from
+            # the name
+            status, jid = self.list_get_jid(uuid_full.split()[0])
 
             if status:
                 state = "up"

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1105,7 +1105,26 @@ class IOCage(object):
                         jail_list.append({uuid: state})
                     elif prop == "all":
                         _props = {}
-                        props = ioc_json.IOCJson(path).json_get_value(prop)
+                        try:
+                            props = ioc_json.IOCJson(path).json_get_value(prop)
+                        except (Exception, SystemExit):
+                            # Jail is corrupt, we want all the keys to exist.
+                            # So we will take the defaults and let the user
+                            # know that they are not correct.
+                            def_props = ioc_json.IOCJson().json_get_value(
+                                'all',
+                                default=True
+                            )
+                            props = {
+                                x: 'N/A'
+                                for x in def_props
+                            }
+                            props['host_hostuuid'] = f'{uuid} - CORRUPTED'
+                            props['state'] = state
+                            props['release'] = 'N/A'
+                            jail_list.append({uuid: props})
+
+                            continue
 
                         # We want this sorted below, so we add it to the old
                         # dict

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1119,8 +1119,8 @@ class IOCage(object):
                                 x: 'N/A'
                                 for x in def_props
                             }
-                            props['host_hostuuid'] = f'{uuid} - CORRUPTED'
-                            props['state'] = state
+                            props['host_hostuuid'] = uuid
+                            props['state'] = 'CORRUPT'
                             props['release'] = 'N/A'
                             jail_list.append({uuid: props})
 


### PR DESCRIPTION
Previous behavior was to immediately die

- Add 3 new exceptions for misconfigured jails
- Start to use them in ioc_json
- Show corrupt jails in iocage list
- Return corrupt jails in get all recursive API with default key values being replaced with N/A (FreeNAS focused)

FreeNAS Ticket: #51997