### PR TITLE
Write partial configurations by default

### DIFF
--- a/iocage_cli/migrate.py
+++ b/iocage_cli/migrate.py
@@ -76,7 +76,7 @@ def cli(force, delete):
         iocroot = ioc_json.IOCJson(pool).json_get_value("iocroot")
         jail = f"{pool}/iocage/jails/{uuid}"
         jail_old = f"{pool}/iocage/jails_old/{uuid}"
-        conf = ioc_json.IOCJson(path).json_load()
+        conf = ioc_json.IOCJson(path).json_get_value('all')
 
         try:
             tag = conf["tag"]

--- a/iocage_cli/snapremove.py
+++ b/iocage_cli/snapremove.py
@@ -63,7 +63,7 @@ def cli(jail, name):
         })
 
     # Looks like foo/iocage/jails/df0ef69a-57b6-4480-b1f8-88f7b6febbdf@BAR
-    conf = ioc_json.IOCJson(path).json_load()
+    conf = ioc_json.IOCJson(path).json_get_value('all')
 
     if conf["template"] == "yes":
         target = f"{pool}/iocage/templates/{uuid}@{name}"

--- a/iocage_lib/ioc_destroy.py
+++ b/iocage_lib/ioc_destroy.py
@@ -86,8 +86,7 @@ class IOCDestroy(object):
             _path = _path if _path != "none" else None
 
             if (dataset.name.endswith(uuid) or root) and _path is not None:
-                conf = iocage_lib.ioc_json.IOCJson(_path).json_load()
-                iocage_lib.ioc_stop.IOCStop(uuid, _path, conf, silent=True)
+                iocage_lib.ioc_stop.IOCStop(uuid, _path, silent=True)
 
     def __destroy_leftovers__(self, dataset, clean=False):
         """Removes parent datasets and logs."""
@@ -245,8 +244,7 @@ class IOCDestroy(object):
             return
 
         try:
-            conf = iocage_lib.ioc_json.IOCJson(path).json_load()
-            iocage_lib.ioc_stop.IOCStop(uuid, path, conf, silent=True)
+            iocage_lib.ioc_stop.IOCStop(uuid, path, silent=True)
         except (FileNotFoundError, RuntimeError, libzfs.ZFSException,
                 SystemExit):
             # Broad exception as we don't care why this failed. iocage

--- a/iocage_lib/ioc_exec.py
+++ b/iocage_lib/ioc_exec.py
@@ -76,7 +76,8 @@ class IOCExec(object):
         if self.uuid is not None:
             self.status, _ = iocage_lib.ioc_list.IOCList().list_get_jid(
                 self.uuid)
-            self.conf = iocage_lib.ioc_json.IOCJson(self.path).json_load()
+            self.conf = iocage_lib.ioc_json.IOCJson(self.path).json_get_value(
+                'all')
             exec_fib = self.conf["exec_fib"]
 
             self.flight_checks()
@@ -144,8 +145,8 @@ class IOCExec(object):
 
             if self.conf["type"] in (
                     "jail", "plugin", "pluginv2", "clonejail"):
-                iocage_lib.ioc_start.IOCStart(
-                    self.uuid, self.path, self.conf, silent=True)
+                iocage_lib.ioc_start.IOCStart(self.uuid, self.path,
+                                              silent=True)
             elif self.conf["type"] == "basejail":
                 iocage_lib.ioc_common.logit(
                     {

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -1221,7 +1221,7 @@ class IOCJson(object):
             "owner": ("string", ),
             "priority": str(tuple(range(1, 100))),
             "hostid": ("string", ),
-            "hostid_strict_check": ("no", "yes"),
+            "hostid_strict_check": ("off", "on"),
             "jail_zfs": ("off", "on"),
             "jail_zfs_dataset": ("string", ),
             "jail_zfs_mountpoint": ("string", ),

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -338,7 +338,6 @@ class IOCJson(object):
                                 iocage_lib.ioc_stop.IOCStop(
                                     full_uuid,
                                     self.location,
-                                    conf,
                                     silent=True)
 
                             jail_zfs_prop = \
@@ -412,22 +411,23 @@ class IOCJson(object):
                                        f" Please destroy {uuid} and recreate"
                                        " it.")
 
-        try:
-            conf_version = conf["CONFIG_VERSION"]
-
-            if version != conf_version:
-                conf = self.json_check_config(conf)
-        except KeyError:
-            conf = self.json_check_config(conf)
+        conf = self.json_check_config(conf)
 
         return conf
 
-    def json_write(self, data, _file="/config.json"):
+    def json_write(self, data, _file="/config.json", defaults=False):
         """Write a JSON file at the location given with supplied data."""
         # Templates need to be set r/w and then back to r/o
-        template = True if data['template'] != 'no' else False
-        jail_dataset = self.zfs.get_dataset_by_path(self.location).name \
-            if template else None
+        try:
+            template = True if data['template'] != 'no' else False
+            jail_dataset = self.zfs.get_dataset_by_path(self.location).name \
+                if template else None
+        except KeyError:
+            # Not a template, it would exist in the configuration otherwise
+            template = False
+
+        # _file is a full path when creating defaults
+        write_location = f'{self.location}{_file}' if not defaults else _file
 
         if template:
             try:
@@ -442,8 +442,7 @@ class IOCJson(object):
                     exception=ioc_exceptions.CommandFailed
                 )
 
-        with iocage_lib.ioc_common.open_atomic(self.location + _file,
-                                               'w') as out:
+        with iocage_lib.ioc_common.open_atomic(write_location, 'w') as out:
             json.dump(data, out, sort_keys=True, indent=4, ensure_ascii=False)
 
         if template:
@@ -613,16 +612,22 @@ class IOCJson(object):
             except Exception:
                 raise RuntimeError(f"{self.location} not found!")
         elif prop == "all":
+            d_conf = self.json_check_default_config()
             conf = self.json_load()
+            d_conf.update(conf)
 
-            return conf
+            return d_conf
         else:
             conf = self.json_load()
 
             if prop == "last_started" and conf[prop] == "none":
                 return "never"
             else:
-                return conf[prop]
+                try:
+                    return conf[prop]
+                except KeyError:
+                    default_props = self.json_check_default_config()
+                    return default_props[prop]
 
     def json_set_value(self, prop, _import=False, default=False):
         """Set a property for the specified jail."""
@@ -878,112 +883,70 @@ class IOCJson(object):
 
         return version
 
-    def json_check_config(self, conf, default=False):
+    def check_jail_config(self, iocroot, conf):
         """
-        Takes JSON as input and checks to see what is missing and adds the
-        new keys with their default values if missing.
+        Checks the jails configuration and migrates anything needed
         """
-        _, iocroot = _get_pool_and_iocroot()
+        release = conf.get("release", None)
         renamed = False
 
-        if os.geteuid() != 0:
+        if release is None:
+            err_name = self.location.rsplit("/", 1)[-1]
             iocage_lib.ioc_common.logit(
                 {
                     "level":
                     "EXCEPTION",
                     "message":
-                    "You need to be root to convert the"
-                    " configurations to the new format!"
+                    f"{err_name} has a corrupt configuration,"
+                    " please destroy the jail."
                 },
                 _callback=self.callback,
                 silent=self.silent)
-        conf['CONFIG_VERSION'] = self.json_get_version()
 
-        # Version 2 keys
-        if not conf.get('sysvmsg'):
-            conf['sysvmsg'] = 'new'
-        if not conf.get('sysvsem'):
-            conf['sysvsem'] = 'new'
-        if not conf.get('sysvshm'):
-            conf['sysvshm'] = 'new'
+        release = release.rsplit("-p", 1)[0]
+        cloned_release = conf.get("cloned_release", "LEGACY_JAIL")
 
-        # Version 3 keys
-        if not default:
-            release = conf.get("release", None)
+        try:
+            freebsd_version = f"{iocroot}/releases/{release}/root/bin/" \
+                "freebsd-version"
+        except FileNotFoundError:
+            freebsd_version = f"{iocroot}/templates/" \
+                f"{conf['host_hostuuid']}" \
+                              "/root/bin/freebsd-version"
+        except KeyError:
+            # At this point it should be a real misconfigured jail
+            uuid = self.location.rsplit("/", 1)[-1]
+            raise RuntimeError("Configuration is missing!"
+                               f" Please destroy {uuid} and recreate"
+                               " it.")
 
-            if release is None:
-                err_name = self.location.rsplit("/", 1)[-1]
+        if release[:4].endswith("-"):
+            # 9.3-RELEASE and under don't actually have this binary.
+            release = conf["release"]
+        elif release == 'EMPTY':
+            pass
+        else:
+            try:
+                with open(freebsd_version, "r") as r:
+                    for line in r:
+                        if line.startswith("USERLAND_VERSION"):
+                            release = line.rstrip().partition("=")[2]
+                            release = release.strip('"')
+            except Exception as e:
                 iocage_lib.ioc_common.logit(
                     {
-                        "level":
-                        "EXCEPTION",
-                        "message":
-                        f"{err_name} has a corrupt configuration,"
-                        " please destroy the jail."
-                    },
-                    _callback=self.callback,
-                    silent=self.silent)
+                        'level': 'EXCEPTION',
+                        'message': 'Exception:'
+                        f' "{e.__class__.__name__}:{str(e)}" occured\n'
+                        f"Loading {uuid}'s configuration failed"
+                    }
+                )
 
-            release = release.rsplit("-p", 1)[0]
-            cloned_release = conf.get("cloned_release", "LEGACY_JAIL")
+            cloned_release = conf["release"]
 
-            try:
-                freebsd_version = f"{iocroot}/releases/{release}/root/bin/" \
-                    "freebsd-version"
-            except FileNotFoundError:
-                freebsd_version = f"{iocroot}/templates/" \
-                    f"{conf['host_hostuuid']}" \
-                                  "/root/bin/freebsd-version"
-            except KeyError:
-                # At this point it should be a real misconfigured jail
-                uuid = self.location.rsplit("/", 1)[-1]
-                raise RuntimeError("Configuration is missing!"
-                                   f" Please destroy {uuid} and recreate"
-                                   " it.")
-
-            if release[:4].endswith("-"):
-                # 9.3-RELEASE and under don't actually have this binary.
-                release = conf["release"]
-            elif release == 'EMPTY':
-                pass
-            else:
-                try:
-                    with open(freebsd_version, "r") as r:
-                        for line in r:
-                            if line.startswith("USERLAND_VERSION"):
-                                release = line.rstrip().partition("=")[2]
-                                release = release.strip('"')
-                except Exception as e:
-                    iocage_lib.ioc_common.logit(
-                        {
-                            'level': 'EXCEPTION',
-                            'message': 'Exception:'
-                            f' "{e.__class__.__name__}:{str(e)}" occured\n'
-                            f"Loading {uuid}'s configuration failed"
-                        }
-                    )
-
-                cloned_release = conf["release"]
-
-            # Set all Version 3 keys
-            conf["release"] = release
-            conf["cloned_release"] = cloned_release
-
-            # Version 4 keys
-            if not conf.get('basejail'):
-                conf['basejail'] = 'no'
-
-        # Version 5 keys
-        if not conf.get('comment'):
-            conf['comment'] = 'none'
-
-        # Version 6 keys
-        if not conf.get('host_time'):
-            conf['host_time'] = 'yes'
-
-        # Version 7 keys
-        if not conf.get('depends'):
-            conf['depends'] = 'none'
+        # Set all Version 3 keys
+        conf["release"] = release
+        conf["cloned_release"] = cloned_release
 
         # Version 8 migration from uuid to tag named dataset
         try:
@@ -1034,6 +997,104 @@ class IOCJson(object):
             # New jail creation
             pass
 
+        try:
+            if not renamed:
+                self.json_write(conf)
+        except FileNotFoundError:
+            # Dataset was renamed.
+            self.location = f"{iocroot}/jails/{tag}"
+
+            self.json_write(conf)
+            messages = collections.OrderedDict(
+                [("1-NOTICE", "*" * 80),
+                 ("2-WARNING", f"Jail: {uuid} was renamed to {tag}"),
+                 ("3-NOTICE",
+                  f"{'*' * 80}\n"), ("4-EXCEPTION",
+                                     "Please issue your command again.")])
+
+            for level, msg in messages.items():
+                level = level.partition("-")[2]
+
+                iocage_lib.ioc_common.logit(
+                    {
+                        "level": level,
+                        "message": msg
+                    },
+                    _callback=self.callback,
+                    silent=self.silent)
+
+        # The above doesn't get triggered with legacy short UUIDs
+        if renamed:
+            self.location = f"{iocroot}/jails/{tag}"
+
+            self.json_write(conf)
+
+            messages = collections.OrderedDict(
+                [("1-NOTICE", "*" * 80),
+                 ("2-WARNING", f"Jail: {uuid} was renamed to {tag}"),
+                 ("3-NOTICE",
+                  f"{'*' * 80}\n"), ("4-EXCEPTION",
+                                     "Please issue your command again.")])
+
+            for level, msg in messages.items():
+                level = level.partition("-")[2]
+
+                iocage_lib.ioc_common.logit(
+                    {
+                        "level": level,
+                        "message": msg
+                    },
+                    _callback=self.callback,
+                    silent=self.silent)
+        return conf
+
+    def json_check_config(self, conf, default=False):
+        """
+        Takes JSON as input and checks to see what is missing and adds the
+        new keys to the defaults with their default values if missing.
+        """
+        _, iocroot = _get_pool_and_iocroot()
+
+        if os.geteuid() != 0:
+            iocage_lib.ioc_common.logit(
+                {
+                    "level":
+                    "EXCEPTION",
+                    "message": "You need to be root to convert the"
+                        " configurations to the new format!"
+                },
+                _callback=self.callback,
+                silent=self.silent)
+
+        if not default:
+            jail_conf = self.check_jail_config(iocroot, conf)
+
+        conf['CONFIG_VERSION'] = self.json_get_version()
+
+        # Version 2 keys
+        if not conf.get('sysvmsg'):
+            conf['sysvmsg'] = 'new'
+        if not conf.get('sysvsem'):
+            conf['sysvsem'] = 'new'
+        if not conf.get('sysvshm'):
+            conf['sysvshm'] = 'new'
+
+        # Version 4 keys
+        if not conf.get('basejail'):
+            conf['basejail'] = 'no'
+
+        # Version 5 keys
+        if not conf.get('comment'):
+            conf['comment'] = 'none'
+
+        # Version 6 keys
+        if not conf.get('host_time'):
+            conf['host_time'] = 'yes'
+
+        # Version 7 keys
+        if not conf.get('depends'):
+            conf['depends'] = 'none'
+
         # Version 9 keys
         if not conf.get('dhcp'):
             conf['dhcp'] = 'off'
@@ -1061,55 +1122,7 @@ class IOCJson(object):
             conf['allow_tun'] = '0'
 
         if not default:
-            try:
-                if not renamed:
-                    self.json_write(conf)
-            except FileNotFoundError:
-                # Dataset was renamed.
-                self.location = f"{iocroot}/jails/{tag}"
-
-                self.json_write(conf)
-                messages = collections.OrderedDict(
-                    [("1-NOTICE", "*" * 80),
-                     ("2-WARNING", f"Jail: {uuid} was renamed to {tag}"),
-                     ("3-NOTICE",
-                      f"{'*' * 80}\n"), ("4-EXCEPTION",
-                                         "Please issue your command again.")])
-
-                for level, msg in messages.items():
-                    level = level.partition("-")[2]
-
-                    iocage_lib.ioc_common.logit(
-                        {
-                            "level": level,
-                            "message": msg
-                        },
-                        _callback=self.callback,
-                        silent=self.silent)
-
-        # The above doesn't get triggered with legacy short UUIDs
-        if renamed:
-            self.location = f"{iocroot}/jails/{tag}"
-
-            self.json_write(conf)
-
-            messages = collections.OrderedDict(
-                [("1-NOTICE", "*" * 80),
-                 ("2-WARNING", f"Jail: {uuid} was renamed to {tag}"),
-                 ("3-NOTICE",
-                  f"{'*' * 80}\n"), ("4-EXCEPTION",
-                                     "Please issue your command again.")])
-
-            for level, msg in messages.items():
-                level = level.partition("-")[2]
-
-                iocage_lib.ioc_common.logit(
-                    {
-                        "level": level,
-                        "message": msg
-                    },
-                    _callback=self.callback,
-                    silent=self.silent)
+            conf.update(jail_conf)
 
         return conf
 
@@ -1840,7 +1853,9 @@ class IOCJson(object):
             "available": "readonly",
             "used": "readonly",
             "dedup": "off",
-            "reservation": "none"
+            "reservation": "none",
+            "depends": "none",
+            "vnet_interfaces": "none"
         }
 
         try:
@@ -1870,6 +1885,7 @@ class IOCJson(object):
             # They may have had new keys added to their default
             # configuration, or it never existed.
             if write:
-                self.json_write(default_props, default_json_location)
+                self.json_write(default_props, default_json_location,
+                                defaults=True)
 
         return default_props

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -897,24 +897,17 @@ class IOCJson(object):
                 },
                 _callback=self.callback,
                 silent=self.silent)
+        conf['CONFIG_VERSION'] = self.json_get_version()
 
         # Version 2 keys
-        try:
-            sysvmsg = conf["sysvmsg"]
-            sysvsem = conf["sysvsem"]
-            sysvshm = conf["sysvshm"]
-        except KeyError:
-            sysvmsg = "new"
-            sysvsem = "new"
-            sysvshm = "new"
-
-        # Set all keys, even if it's the same value.
-        conf["sysvmsg"] = sysvmsg
-        conf["sysvsem"] = sysvsem
-        conf["sysvshm"] = sysvshm
+        if not conf.get('sysvmsg'):
+            conf['sysvmsg'] = 'new'
+        if not conf.get('sysvsem'):
+            conf['sysvsem'] = 'new'
+        if not conf.get('sysvshm'):
+            conf['sysvshm'] = 'new'
 
         # Version 3 keys
-
         if not default:
             release = conf.get("release", None)
 
@@ -977,28 +970,20 @@ class IOCJson(object):
             conf["cloned_release"] = cloned_release
 
             # Version 4 keys
-            try:
-                basejail = conf["basejail"]
-            except KeyError:
-                basejail = "no"
-
-            # Set all keys, even if it's the same value.
-            conf["basejail"] = basejail
+            if not conf.get('basejail'):
+                conf['basejail'] = 'no'
 
         # Version 5 keys
-        try:
-            comment = conf["comment"]
-        except KeyError:
-            comment = "none"
-
-        # Set all keys, even if it's the same value.
-        conf["comment"] = comment
+        if not conf.get('comment'):
+            conf['comment'] = 'none'
 
         # Version 6 keys
-        conf["host_time"] = "yes"
+        if not conf.get('host_time'):
+            conf['host_time'] = 'yes'
 
         # Version 7 keys
-        conf["depends"] = "none"
+        if not conf.get('depends'):
+            conf['depends'] = 'none'
 
         # Version 8 migration from uuid to tag named dataset
         try:
@@ -1050,46 +1035,22 @@ class IOCJson(object):
             pass
 
         # Version 9 keys
-        try:
-            dhcp = conf["dhcp"]
-            bpf = conf["bpf"]
-        except KeyError:
-            dhcp = "off"
-            bpf = "no"
-
-        # Set all keys, even if it's the same value.
-        conf["dhcp"] = dhcp
-        conf["bpf"] = bpf
+        if not conf.get('dhcp'):
+            conf['dhcp'] = 'off'
+        if not conf.get('bpf'):
+            conf['bpf'] = 'no'
 
         # Version 10 keys
-        try:
-            vnet_interfaces = conf["vnet_interfaces"]
-        except KeyError:
-            vnet_interfaces = "none"
-
-        # Set all keys, even if it's the same value.
-        conf["vnet_interfaces"] = vnet_interfaces
-
-        # Set all keys, even if it's the same value.
-        conf["CONFIG_VERSION"] = self.json_get_version()
+        if not conf.get('vnet_interfaces'):
+            conf['vnet_interfaces'] = 'none'
 
         # Version 11 keys
-        try:
-            hostid_strict_check = conf["hostid_strict_check"]
-        except KeyError:
-            hostid_strict_check = "off"
-
-        # Set all keys, even if it's the same value.
-        conf["hostid_strict_check"] = hostid_strict_check
+        if not conf.get('hostid_strict_check'):
+            conf['hostid_strict_check'] = 'off'
 
         # Version 12 keys
-        try:
-            allow_mlock = conf["allow_mlock"]
-        except KeyError:
-            allow_mlock = "0"
-
-        # Set all keys, even if it's the same value.
-        conf["allow_mlock"] = allow_mlock
+        if not conf.get('allow_mlock'):
+            conf['allow_mlock'] = '0'
 
         # Version 13 keys
         if not conf.get('vnet_default_interface'):
@@ -1127,7 +1088,6 @@ class IOCJson(object):
                         silent=self.silent)
 
         # The above doesn't get triggered with legacy short UUIDs
-
         if renamed:
             self.location = f"{iocroot}/jails/{tag}"
 

--- a/iocage_lib/ioc_list.py
+++ b/iocage_lib/ioc_list.py
@@ -129,7 +129,9 @@ class IOCList(object):
                 }
 
             uuid = conf["host_hostuuid"]
-            ip4 = conf["ip4_addr"] if conf["dhcp"] != "on" else "DHCP"
+            ip4 = conf.get('ip4_addr', 'none')
+            dhcp = conf.get('dhcp', 'off')
+            ip4 = ip4 if dhcp != 'on' else 'DHCP'
 
             jail_list.append([uuid, ip4])
 
@@ -159,7 +161,9 @@ class IOCList(object):
         for jail in jails:
             mountpoint = jail.properties["mountpoint"].value
             try:
-                conf = iocage_lib.ioc_json.IOCJson(mountpoint).json_load()
+                conf = iocage_lib.ioc_json.IOCJson(mountpoint).json_get_value(
+                    'all'
+                )
                 state = ''
             except (Exception, SystemExit):
                 # Jail is corrupt, we want all the keys to exist.

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -151,7 +151,7 @@ class IOCPlugin(object):
                 props, jail_name)
             location = f"{self.iocroot}/jails/{jail_name}"
             self.__fetch_plugin_install_packages__(jail_name, jaildir, conf,
-                                                   _conf, pkg, props, repo_dir)
+                                                   pkg, props, repo_dir)
             self.__fetch_plugin_post_install__(conf, _conf, jaildir, jail_name)
         except Exception as e:
             if not self.keep_jail_on_failure:
@@ -352,7 +352,7 @@ class IOCPlugin(object):
         jaildir = f"{self.iocroot}/jails/{uuid}"
         repo_dir = f"{jaildir}/root/usr/local/etc/pkg/repos"
         path = f"{self.pool}/iocage/jails/{uuid}"
-        _conf = iocage_lib.ioc_json.IOCJson(jaildir).json_load()
+        _conf = iocage_lib.ioc_json.IOCJson(jaildir).json_get_value('all')
 
         # We do this test again as the user could supply a malformed IP to
         # fetch that bypasses the more naive check in cli/fetch
@@ -377,8 +377,8 @@ class IOCPlugin(object):
 
         return uuid, jaildir, _conf, repo_dir
 
-    def __fetch_plugin_install_packages__(self, uuid, jaildir, conf, _conf,
-                                          pkg_repos, create_props, repo_dir):
+    def __fetch_plugin_install_packages__(self, uuid, jaildir, conf, pkg_repos,
+                                          create_props, repo_dir):
         """Attempts to start the jail and install the packages"""
         kmods = conf.get("kmods", {})
         secure = True if "https://" in conf["packagesite"] else False
@@ -413,7 +413,7 @@ class IOCPlugin(object):
                 pkglist=["ca_root_nss"],
                 silent=True,
                 callback=self.callback).create_install_packages(
-                    uuid, jaildir, _conf)
+                    uuid, jaildir)
 
             if err:
                 iocage_lib.ioc_common.logit(
@@ -498,7 +498,7 @@ fingerprint: {fingerprint}
             silent=True,
             plugin=True,
             callback=self.callback).create_install_packages(
-                uuid, jaildir, _conf, repo=conf["packagesite"])
+                uuid, jaildir, repo=conf["packagesite"])
 
         if err:
             iocage_lib.ioc_common.logit(
@@ -966,11 +966,7 @@ fingerprint: {fingerprint}
                     0,
                     pkglist=["ca_root_nss"],
                     silent=True, callback=self.callback
-                ).create_install_packages(
-                    self.plugin,
-                    path,
-                    conf
-                )
+                ).create_install_packages(self.plugin, path)
 
             if err:
                 self.__rollback_jail__(name="update")
@@ -993,7 +989,6 @@ fingerprint: {fingerprint}
                 callback=self.callback).create_install_packages(
                 self.plugin,
                 path,
-                conf,
                 repo=plugin_conf["packagesite"])
 
             if err:
@@ -1007,9 +1002,6 @@ fingerprint: {fingerprint}
                     _callback=self.callback)
 
     def upgrade(self):
-        jail_conf = iocage_lib.ioc_json.IOCJson(
-            location=f"{self.iocroot}/jails/{self.plugin}").json_load()
-
         iocage_lib.ioc_common.logit(
             {
                 "level": "INFO",
@@ -1067,7 +1059,7 @@ fingerprint: {fingerprint}
             silent=self.silent)
 
         new_release = iocage_lib.ioc_upgrade.IOCUpgrade(
-            jail_conf, plugin_release, path, silent=True).upgrade_basejail(
+            plugin_release, path, silent=True).upgrade_basejail(
                 snapshot=False)
 
         self.silent = True

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -46,11 +46,11 @@ class IOCStart(object):
     for them. It also finds any scripts the user supplies for exec_*
     """
 
-    def __init__(self, uuid, path, conf, silent=False,
-                 callback=None, is_depend=False):
+    def __init__(self, uuid, path, silent=False, callback=None,
+                 is_depend=False):
         self.uuid = uuid.replace(".", "_")
         self.path = path
-        self.conf = conf
+        self.conf = iocage_lib.ioc_json.IOCJson(path).json_get_value('all')
         self.callback = callback
         self.silent = silent
         self.is_depend = is_depend
@@ -452,8 +452,8 @@ class IOCStart(object):
 
                 if failed_dhcp:
                     iocage_lib.ioc_stop.IOCStop(self.uuid, self.path,
-                                                self.conf, force=True,
-                                                silent=True)
+                                                force=True, silent=True
+                    )
 
                     iocage_lib.ioc_common.logit({
                         "level": "EXCEPTION",
@@ -485,9 +485,9 @@ class IOCStart(object):
                     _callback=self.callback,
                     silent=self.silent)
 
-            iocage_lib.ioc_stop.IOCStop(self.uuid, self.path,
-                                        self.conf, force=True,
-                                        silent=True)
+            iocage_lib.ioc_stop.IOCStop(self.uuid, self.path, force=True,
+                                        silent=True
+            )
 
             iocage_lib.ioc_common.logit({
                 "level": "EXCEPTION",

--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -33,18 +33,17 @@ import iocage_lib.ioc_list
 class IOCStop(object):
     """Stops a jail and unmounts the jails mountpoints."""
 
-    def __init__(self, uuid, path, conf,
-                 silent=False, callback=None, force=False):
+    def __init__(self, uuid, path, silent=False, callback=None, force=False):
         self.pool = iocage_lib.ioc_json.IOCJson(" ").json_get_value("pool")
         self.iocroot = iocage_lib.ioc_json.IOCJson(
             self.pool).json_get_value("iocroot")
         self.uuid = uuid.replace(".", "_")
         self.path = path
-        self.conf = conf
+        self.conf = iocage_lib.ioc_json.IOCJson(path).json_get_value('all')
         self.force = force
         self.status, self.jid = iocage_lib.ioc_list.IOCList().list_get_jid(
             uuid)
-        self.nics = conf["interfaces"]
+        self.nics = self.conf["interfaces"]
         self.callback = callback
         self.silent = silent
 

--- a/iocage_lib/ioc_upgrade.py
+++ b/iocage_lib/ioc_upgrade.py
@@ -40,7 +40,6 @@ class IOCUpgrade(object):
     """Will upgrade a jail to the specified RELEASE."""
 
     def __init__(self,
-                 conf,
                  new_release,
                  path,
                  silent=False,
@@ -51,13 +50,13 @@ class IOCUpgrade(object):
             self.pool).json_get_value("iocroot")
         self.freebsd_version = iocage_lib.ioc_common.checkoutput(
             ["freebsd-version"])
-        self.conf = conf
-        self.uuid = conf["host_hostuuid"]
+        self.conf = iocage_lib.ioc_json.IOCJson(path).json_get_value('all')
+        self.uuid = self.conf["host_hostuuid"]
         self.host_release = os.uname()[2]
-        self.cloned_release = conf["cloned_release"]
-        _release = conf["release"].rsplit("-", 1)[0]
+        self.cloned_release = self.conf["cloned_release"]
+        _release = self.conf["release"].rsplit("-", 1)[0]
         self.jail_release = _release if "-RELEASE" in _release else \
-            conf["release"]
+            self.conf["release"]
         self.new_release = new_release
         self.path = path
         self.status, self.jid = iocage_lib.ioc_list.IOCList.list_get_jid(

--- a/tests/unit_tests/1000_lib_start_test.py
+++ b/tests/unit_tests/1000_lib_start_test.py
@@ -29,7 +29,7 @@ import iocage_lib.ioc_start as ioc_start
 def test_should_return_mtu_of_first_member(mock_checkoutput):
     mock_checkoutput.side_effect = [bridge_if_config, member_if_config]
 
-    mtu = ioc_start.IOCStart("", "", "").find_bridge_mtu('bridge0')
+    mtu = ioc_start.IOCStart("", "").find_bridge_mtu('bridge0')
     assert mtu == '1500'
     mock_checkoutput.assert_has_calls([mock.call(["ifconfig", "bridge0"]),
                                        mock.call(["ifconfig", "bge0"])])
@@ -40,7 +40,7 @@ def test_should_return_mtu_of_first_member_with_description(mock_checkoutput):
     mock_checkoutput.side_effect = [bridge_with_description_if_config,
                                     member_if_config]
 
-    mtu = ioc_start.IOCStart("", "", "").find_bridge_mtu('bridge0')
+    mtu = ioc_start.IOCStart("", "").find_bridge_mtu('bridge0')
     assert mtu == '1500'
     mock_checkoutput.assert_has_calls([mock.call(["ifconfig", "bridge0"]),
                                        mock.call(["ifconfig", "bge0"])])
@@ -51,7 +51,7 @@ def test_should_return_default_mtu_if_no_members(mock_checkoutput):
     mock_checkoutput.side_effect = [bridge_with_no_members_if_config,
                                     member_if_config]
 
-    mtu = ioc_start.IOCStart("", "", "").find_bridge_mtu('bridge0')
+    mtu = ioc_start.IOCStart("", "").find_bridge_mtu('bridge0')
     assert mtu == '1500'
     mock_checkoutput.called_with(["ifconfig", "bridge0"])
 


### PR DESCRIPTION
- Fix bad behavior with host_strict_id_check
- Simplify config upgrades
- Configurations now show what the user has set, with a few jail specific properties
- Removed many instances of passing configuration to certain classes
- We now merge the default props with the jail props when reading them in via json_get_value('all')

FreeNAS Ticket: #58149