### PR TITLE
Fallback to using the jails freebsd_version if the RELEASE one fails

### DIFF
--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -888,7 +888,6 @@ class IOCJson(object):
         Checks the jails configuration and migrates anything needed
         """
         release = conf.get("release", None)
-        notes = conf.get('notes', 'none')
         template = conf.get('template', 'no')
         renamed = False
 
@@ -914,8 +913,7 @@ class IOCJson(object):
         except FileNotFoundError:
             if template == 'yes':
                 freebsd_version = f"{iocroot}/templates/" \
-                    f"{conf['host_hostuuid']}" \
-                                  "/root/bin/freebsd-version"
+                    f"{conf['host_hostuuid']}/root/bin/freebsd-version"
             else:
                 temp_uuid = self.location.rsplit("/", 1)[-1]
                 freebsd_version = f'{iocroot}/jails/{temp_uuid}/root/bin/' \

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -888,6 +888,8 @@ class IOCJson(object):
         Checks the jails configuration and migrates anything needed
         """
         release = conf.get("release", None)
+        notes = conf.get('notes', 'none')
+        template = conf.get('template', 'no')
         renamed = False
 
         if release is None:
@@ -907,12 +909,17 @@ class IOCJson(object):
         cloned_release = conf.get("cloned_release", "LEGACY_JAIL")
 
         try:
-            freebsd_version = f"{iocroot}/releases/{release}/root/bin/" \
-                "freebsd-version"
+            freebsd_version = f'{iocroot}/releases/{release}/root/bin/' \
+                'freebsd-version'
         except FileNotFoundError:
-            freebsd_version = f"{iocroot}/templates/" \
-                f"{conf['host_hostuuid']}" \
-                              "/root/bin/freebsd-version"
+            if template == 'yes':
+                freebsd_version = f"{iocroot}/templates/" \
+                    f"{conf['host_hostuuid']}" \
+                                  "/root/bin/freebsd-version"
+            else:
+                temp_uuid = self.location.rsplit("/", 1)[-1]
+                freebsd_version = f'{iocroot}/jails/{temp_uuid}/root/bin/' \
+                    'freebsd-version'
         except KeyError:
             # At this point it should be a real misconfigured jail
             uuid = self.location.rsplit("/", 1)[-1]


### PR DESCRIPTION
Thick/Empty jails and warden migration jails from FreeNAS fall in this category.

Ticket: #58365