### PR TITLE
Correctly add bpf to devfs rules, change creation warnings for props

### DIFF
--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -706,10 +706,10 @@ def generate_devfs_ruleset(conf, paths=None, includes=None, callback=None,
         devfs_dict.update(paths)
 
     # We may end up setting all of these.
+    if conf['bpf'] == 'yes':
+        devfs_dict['bpf*'] = None
     if conf['allow_tun'] == '1':
         devfs_dict['tun*'] = None
-    if conf['dhcp'] == 'on':
-        devfs_dict['bpf*'] = None
 
     for include in devfs_includes:
         su.run(

--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -365,27 +365,40 @@ class IOCCreate(object):
                     if 'vnet=on' not in self.props:
                         iocage_lib.ioc_common.logit({
                             'level': 'WARNING',
-                            'message': 'accept_rtadv requires vnet=on!'
+                            'message': 'accept_rtadv requires vnet,'
+                            ' setting to on!'
                         },
                             _callback=self.callback,
                             silent=self.silent)
+                        conf['vnet'] = 'on'
 
                     rtsold_enable = 'YES'
             elif key == 'dhcp' and value == 'on':
                 if 'vnet=on' not in self.props:
                     iocage_lib.ioc_common.logit({
                         'level': 'WARNING',
-                        'message': 'dhcp requires vnet=on!'
+                        'message': 'dhcp requires vnet, setting to on!'
                     },
                         _callback=self.callback,
                         silent=self.silent)
+                    config['vnet'] = 'on'
                 if 'bpf=yes' not in self.props:
                     iocage_lib.ioc_common.logit({
                         'level': 'WARNING',
-                        'message': 'dhcp requires bpf=yes!'
+                        'message': 'dhcp requires bpf, setting to yes!'
                     },
                         _callback=self.callback,
                         silent=self.silent)
+                    config['bpf'] = 'yes'
+            elif key == 'bpf' and value == 'yes':
+                if 'vnet=on' not in self.props:
+                    iocage_lib.ioc_common.logit({
+                        'level': 'WARNING',
+                        'message': 'bpf requires vnet, setting to on!'
+                    },
+                        _callback=self.callback,
+                        silent=self.silent)
+                    config['vnet'] = 'on'
 
             try:
                 value, config = iocjson.json_check_prop(key, value, config)

--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -370,7 +370,7 @@ class IOCCreate(object):
                         },
                             _callback=self.callback,
                             silent=self.silent)
-                        conf['vnet'] = 'on'
+                        config['vnet'] = 'on'
 
                     rtsold_enable = 'YES'
             elif key == 'dhcp' and value == 'on':

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -146,25 +146,35 @@ class IOCStart(object):
         vnet_interfaces = self.conf["vnet_interfaces"]
         ip6_addr = self.conf["ip6_addr"]
         prop_missing = False
+        prop_missing_msgs = []
 
         if dhcp == "on":
             if bpf != "yes":
-                msg = f"{self.uuid}: dhcp requires bpf=yes!"
+                prop_missing_msgs.append(
+                    f"{self.uuid}: dhcp requires bpf=yes!"
+                )
                 prop_missing = True
             elif self.conf["vnet"] != "on":
                 # We are already setting a vnet variable below.
-                msg = f"{self.uuid}: dhcp requires vnet=on!"
+                prop_missing_msgs.append(
+                    f"{self.uuid}: dhcp requires vnet=on!"
+                )
                 prop_missing = True
 
-        if 'accept_rtadv' in ip6_addr:
-            if self.conf['vnet'] != 'on':
-                msg = f'{self.uuid}: accept_rtadv requires vnet=on!'
-                prop_missing = True
+        if 'accept_rtadv' in ip6_addr and self.conf['vnet'] != 'on':
+            prop_missing_msgs.append(
+                f'{self.uuid}: accept_rtadv requires vnet=on!'
+            )
+            prop_missing = True
+
+        if bpf == 'yes' and self.conf['vnet'] != 'on':
+            prop_missing_msgs.append(f'{self.uuid}: bpf requires vnet=on!')
+            prop_missing = True
 
         if prop_missing:
             iocage_lib.ioc_common.logit({
                 "level": "EXCEPTION",
-                "message": msg
+                "message": '\n'.join(prop_missing_msgs)
             }, _callback=self.callback,
                 silent=self.silent)
 


### PR DESCRIPTION
Instead of warning the user they need these, we set them for the user in addition to the warning.

Also show all missing props during start.

Ticket: #53334