### PR TITLE
Fix tests and default configuration loading in ioc_json

### DIFF
--- a/iocage_cli/__init__.py
+++ b/iocage_cli/__init__.py
@@ -84,6 +84,11 @@ class IOCLogger(object):
         self.log_file = os.environ.get("IOCAGE_LOGFILE", "/var/log/iocage.log")
         self.colorize = os.environ.get("IOCAGE_COLOR", "FALSE")
         logger = logging.getLogger("iocage")
+        
+        if logger.hasHandlers():
+            # If we're imported multiple times (like tests) this will prevent
+            # a large duplicate flood of text.
+            logger.handlers = []
 
         logger.setLevel(logging.DEBUG)
         logging.addLevelName(5, "SPAM")
@@ -115,7 +120,7 @@ class IOCLogger(object):
                 '': {
                     'handlers': ['file'],
                     'level': 'DEBUG',
-                    'propagate': True
+                    'propagate': False
                 },
             },
         }

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -472,8 +472,7 @@ class IOCJson(object):
 
         if default:
             _, iocroot = _get_pool_and_iocroot()
-            with open(f"{iocroot}/defaults.json", "r") as default_json:
-                conf = json.load(default_json)
+            conf = self.json_check_default_config()
 
             if prop == "all":
                 return conf

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -621,7 +621,7 @@ class IOCJson(object):
 
             return d_conf
         else:
-            conf = self.json_load()
+            conf, write = self.json_load()
 
             if prop == "last_started" and conf[prop] == "none":
                 return "never"
@@ -632,12 +632,15 @@ class IOCJson(object):
                     default_props = self.json_check_default_config()
                     return default_props[prop]
 
+            if write:
+                self.json_write(conf)
+
     def json_set_value(self, prop, _import=False, default=False):
         """Set a property for the specified jail."""
         key, _, value = prop.partition("=")
 
         if not default:
-            conf = self.json_load()
+            conf, write = self.json_load()
             uuid = conf["host_hostuuid"]
             status, jid = iocage_lib.ioc_list.IOCList().list_get_jid(uuid)
             conf[key] = value
@@ -798,10 +801,11 @@ class IOCJson(object):
                         },
                         _callback=self.callback,
                         silent=self.silent)
+            if write:
+                self.json_write(conf)
         else:
             _, iocroot = _get_pool_and_iocroot()
-            with open(f"{iocroot}/defaults.json", "r") as default_json:
-                conf = json.load(default_json)
+            conf = self.json_check_default_config()
 
         if not default:
             value, conf = self.json_check_prop(key, value, conf)
@@ -1410,7 +1414,7 @@ class IOCJson(object):
 
     def json_plugin_get_value(self, prop):
         pool, iocroot = _get_pool_and_iocroot()
-        conf = self.json_load()
+        conf, write = self.json_load()
         uuid = conf["host_hostuuid"]
         _path = self.zfs_get_property(f"{pool}/iocage/jails/{uuid}",
                                       "mountpoint")
@@ -1455,9 +1459,12 @@ class IOCJson(object):
                 _callback=self.callback,
                 silent=self.silent)
 
+        if write:
+            self.json_write(conf)
+
     def json_plugin_set_value(self, prop):
         pool, iocroot = _get_pool_and_iocroot()
-        conf = self.json_load()
+        conf, write = self.json_load()
         uuid = conf["host_hostuuid"]
         _path = self.zfs_get_property(f"{pool}/iocage/jails/{uuid}",
                                       "mountpoint")
@@ -1559,6 +1566,9 @@ class IOCJson(object):
                 },
                 _callback=self.callback,
                 silent=self.silent)
+
+        if write:
+            self.json_write(conf)
 
     def json_migrate_uuid_to_tag(self, uuid, tag, state, conf):
         """This will migrate an old uuid + tag jail to a tag only one"""

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -943,7 +943,7 @@ fingerprint: {fingerprint}
     def __update_pkg_install__(self, plugin_conf):
         """Installs all pkgs listed in the plugins configuration"""
         path = f"{self.iocroot}/jails/{self.plugin}"
-        conf = iocage_lib.ioc_json.IOCJson(
+        conf, write = iocage_lib.ioc_json.IOCJson(
             location=path).json_load()
 
         secure = True if "https://" in plugin_conf["packagesite"] else False
@@ -1000,6 +1000,9 @@ fingerprint: {fingerprint}
                         "message": msg
                     },
                     _callback=self.callback)
+
+        if write:
+            self.json_write(conf)
 
     def upgrade(self):
         iocage_lib.ioc_common.logit(
@@ -1199,7 +1202,7 @@ fingerprint: {fingerprint}
 
     def __check_manifest__(self, plugin_conf):
         """If the Major ABI changed, they cannot update anymore."""
-        jail_conf = iocage_lib.ioc_json.IOCJson(
+        jail_conf, write = iocage_lib.ioc_json.IOCJson(
             location=f"{self.iocroot}/jails/{self.plugin}").json_load()
 
         jail_rel = int(jail_conf["release"].split(".", 1)[0])
@@ -1219,6 +1222,9 @@ fingerprint: {fingerprint}
                     " 'upgrade' instead."
                 },
                 _callback=self.callback)
+
+        if write:
+            self.json_write(conf)
 
     def __fetch_release__(self, release):
         """Will call fetch to get the new RELEASE the plugin will rely on"""

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -47,15 +47,16 @@ class IOCStart(object):
     """
 
     def __init__(self, uuid, path, silent=False, callback=None,
-                 is_depend=False):
+                 is_depend=False, unit_test=False):
         self.uuid = uuid.replace(".", "_")
         self.path = path
-        self.conf = iocage_lib.ioc_json.IOCJson(path).json_get_value('all')
         self.callback = callback
         self.silent = silent
         self.is_depend = is_depend
+        self.unit_test = unit_test
 
-        try:
+        if not self.unit_test:
+            self.conf = iocage_lib.ioc_json.IOCJson(path).json_get_value('all')
             self.pool = iocage_lib.ioc_json.IOCJson(" ").json_get_value("pool")
             self.iocroot = iocage_lib.ioc_json.IOCJson(
                 self.pool).json_get_value("iocroot")
@@ -66,10 +67,6 @@ class IOCStart(object):
 
             self.exec_fib = self.conf["exec_fib"]
             self.__start_jail__()
-        except TypeError:
-            # Bridge MTU unit tests will not have these
-            # TODO: Something less terrible
-            pass
 
     def __start_jail__(self):
         """
@@ -950,11 +947,10 @@ class IOCStart(object):
         ]
 
     def find_bridge_mtu(self, bridge):
-        try:
+        if self.unit_test:
+            dhcp = 'off'
+        else:
             dhcp = self.get("dhcp")
-        except Exception:
-            # To spoof unit test.
-            dhcp = "off"
 
         try:
             if dhcp == "on":

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = -v -x -rs --ignore=setup.py --pep8 --cov-report term-missing --cov=iocage iocage tests
+addopts = -v -x -rs --ignore=setup.py --pep8 --cov-report term-missing --cov=iocage tests
 pep8maxlinelength = 80
 pep8ignore = * ALL
 [aliases]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ from iocage_lib.ioc_common import checkoutput
 def pytest_addoption(parser):
     parser.addoption("--zpool", action="store", default=None,
                      help="Specify a zpool to use.")
-    parser.addoption("--release", action="store", default="11.0-RELEASE",
+    parser.addoption("--release", action="store", default="11.2-RELEASE",
                      help="Specify a RELEASE to use.")
     parser.addoption("--server", action="store", default="ftp.freebsd.org",
                      help="FTP server to login to.")

--- a/tests/functional_tests/0002_fetch_test.py
+++ b/tests/functional_tests/0002_fetch_test.py
@@ -41,7 +41,7 @@ def test_fetch(release, server, user, password, auth, root_dir, http, _file,
         release = re.sub(r"\W\w.", "-", release)
 
     # Type Errors are bad mmmkay
-    command = ["fetch", "-r", release]
+    command = ["fetch", "-r", release, "-F", "base.txz"]
     command += ["-s", server] if server else []
     command += ["-h"] if http else []
     command += ["-f", _file] if _file else []

--- a/tests/unit_tests/1000_lib_start_test.py
+++ b/tests/unit_tests/1000_lib_start_test.py
@@ -29,7 +29,7 @@ import iocage_lib.ioc_start as ioc_start
 def test_should_return_mtu_of_first_member(mock_checkoutput):
     mock_checkoutput.side_effect = [bridge_if_config, member_if_config]
 
-    mtu = ioc_start.IOCStart("", "").find_bridge_mtu('bridge0')
+    mtu = ioc_start.IOCStart("", "", unit_test=True).find_bridge_mtu('bridge0')
     assert mtu == '1500'
     mock_checkoutput.assert_has_calls([mock.call(["ifconfig", "bridge0"]),
                                        mock.call(["ifconfig", "bge0"])])
@@ -40,7 +40,7 @@ def test_should_return_mtu_of_first_member_with_description(mock_checkoutput):
     mock_checkoutput.side_effect = [bridge_with_description_if_config,
                                     member_if_config]
 
-    mtu = ioc_start.IOCStart("", "").find_bridge_mtu('bridge0')
+    mtu = ioc_start.IOCStart("", "", unit_test=True).find_bridge_mtu('bridge0')
     assert mtu == '1500'
     mock_checkoutput.assert_has_calls([mock.call(["ifconfig", "bridge0"]),
                                        mock.call(["ifconfig", "bge0"])])
@@ -51,7 +51,7 @@ def test_should_return_default_mtu_if_no_members(mock_checkoutput):
     mock_checkoutput.side_effect = [bridge_with_no_members_if_config,
                                     member_if_config]
 
-    mtu = ioc_start.IOCStart("", "").find_bridge_mtu('bridge0')
+    mtu = ioc_start.IOCStart("", "", unit_test=True).find_bridge_mtu('bridge0')
     assert mtu == '1500'
     mock_checkoutput.called_with(["ifconfig", "bridge0"])
 


### PR DESCRIPTION
- Previous behavior in various locations would open the defaults file directly, it should be using the checking mechanism.
- Add a unit_test attribute to IOCStart for the unit test we have currently
- Fix running tests since the module flattening
- Update RELEASE to 11.2-RELEASE by default for fetch test
- Use only base.txz for fetch test to speed up efforts as the others are unused
- Fix lack of writing json if json_load returned True
- Also corrects incorrect parameter assignments.

FreeNAS Ticket: #59004