### PR TITLE
Need 'type' for plugins

### DIFF
--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -345,6 +345,8 @@ class IOCCreate(object):
 
             if key == "boot" and value == "on" and not self.empty:
                 start = True
+            elif self.plugin and key == "type" and value == "pluginv2":
+                config["type"] = value
             elif key == "template" and value == "yes":
                 iocjson.json_write(config)  # Set counts on this.
                 location = location.replace("/jails/", "/templates/")


### PR DESCRIPTION
Without doing so plugins cannot be created. This is a result of jails no longer storing every property.