### PR TITLE
tkt-59841: Show devfs ruleset when starting and return correct one

### DIFF
--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -621,9 +621,20 @@ class IOCJson(object):
             return d_conf
         else:
             conf, write = self.json_load()
+            state, _ = iocage_lib.ioc_list.IOCList().list_get_jid(
+                conf['host_hostuuid'])
 
             if prop == "last_started" and conf[prop] == "none":
                 return "never"
+            elif prop == 'devfs_ruleset' and state:
+                ruleset = su.check_output(
+                    [
+                        'jls', '-j', f'ioc-{conf["host_hostuuid"]}',
+                        'devfs_ruleset'
+                    ]
+                ).decode().rstrip()
+
+                return ruleset
             else:
                 try:
                     return conf[prop]

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -408,6 +408,13 @@ class IOCStart(object):
                 _callback=self.callback,
                 silent=self.silent)
 
+        iocage_lib.ioc_common.logit({
+            'level': 'INFO',
+            'message': f'  + Using devfs_ruleset: {devfs_ruleset}'
+        },
+            _callback=self.callback,
+            silent=self.silent)
+
         os_path = f"{self.path}/root/dev/log"
 
         if not os.path.isfile(os_path) and not os.path.islink(os_path):


### PR DESCRIPTION
If the jail is running, the devfs ruleset will never be correct unless a user is supplying a manual one.

Ticket: #59841