### PR TITLE
tkt-59442: Move updating basejails to base module ioc_fetch

### DIFF
--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -929,6 +929,19 @@ class IOCFetch(object):
             mount_root, self.release
         )
 
+        if self.release != new_release:
+            jails = iocage_lib.ioc_list.IOCList(
+                'uuid', hdr=False).list_datasets()
+
+            for jail, path in jails.items():
+                _json = iocage_lib.ioc_json.IOCJson(path)
+                props = _json.json_get_value('all')
+
+                if props.get('basejail', 'no') == 'yes':
+                    if props['release'] == self.release:
+                        props['release'] = new_release
+                        _json.json_write(props)
+
         return new_release
 
     def __fetch_extract_remove__(self, tar):

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1815,33 +1815,10 @@ class IOCage(object):
                 ioc_json.IOCJson(path).json_write(conf)
             else:
                 # Basejails only need their RELEASE updated
-                new_release = ioc_fetch.IOCFetch(
+                ioc_fetch.IOCFetch(
                     release,
                     callback=self.callback
                 ).fetch_update()
-
-                if release != new_release:
-                    jail_dicts = self.get('all', recursive=True)
-                    for jail in jail_dicts:
-                        # iocage returns UUID: PROPS for dict, we just want
-                        # props without specifying the UUID.
-                        jail = list(jail.values())[0]
-                        jail_uuid = jail['host_hostuuid']
-
-                        if jail.get('template', 'no') != 'no':
-                            path = f'{self.iocroot}/templates/{jail_uuid}'
-                        else:
-                            path = f'{self.iocroot}/jails/{jail_uuid}'
-
-                        basejail = jail['basejail']
-
-                        if basejail == 'yes':
-                            jail_rel = jail['release']
-
-                            # release is the shared parent
-                            if jail_rel == release:
-                                jail['release'] = new_release
-                                ioc_json.IOCJson(path).json_write(jail)
 
             if started:
                 self.silent = True


### PR DESCRIPTION
This has the additional advantage of updating basejails when the release that is fetched is updated.

Improvement suggested by @jsegaert.

Ticket: #59442