### PR TITLE
tkt-60534: Unneeded cloned_release property kept around with thick jails

### DIFF
--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -308,6 +308,7 @@ class IOCCreate(object):
                         },
                             _callback=self.callback,
                             silent=self.silent)
+                    del config['cloned_release']
             else:
                 try:
                     iocage_lib.ioc_common.checkoutput(

--- a/iocage_lib/ioc_upgrade.py
+++ b/iocage_lib/ioc_upgrade.py
@@ -54,7 +54,6 @@ class IOCUpgrade(object):
             '/root', 1)[0]).json_get_value('all')
         self.uuid = self.conf["host_hostuuid"]
         self.host_release = os.uname()[2]
-        self.cloned_release = self.conf["cloned_release"]
         _release = self.conf["release"].rsplit("-", 1)[0]
         self.jail_release = _release if "-RELEASE" in _release else \
             self.conf["release"]


### PR DESCRIPTION
Remove unused variable in IOCUpgrade

FreeNAS Ticket: #60534