### PR TITLE
tkt-61551: Bug fix for always creating jails with name and count flags

### DIFF
--- a/iocage_cli/create.py
+++ b/iocage_cli/create.py
@@ -25,6 +25,7 @@
 import json
 import os
 import re
+import uuid
 
 import click
 import iocage_lib.ioc_common as ioc_common
@@ -81,11 +82,24 @@ def validate_count(ctx, param, value):
 @click.option("--short", "-s", is_flag=True, default=False,
               help="Use a short UUID of 8 characters instead of the default"
                    " 36.")
-@click.option("--force", "-f", is_flag=True, default=False,
-              help="Skip the interactive question.")
 @click.argument("props", nargs=-1)
 def cli(release, template, count, props, pkglist, basejail, thickjail, empty,
-        short, name, _uuid, force, thickconfig):
+        short, name, _uuid, thickconfig):
+
+    if _uuid:
+        try:
+            uuid.UUID(_uuid, version=4)
+        except ValueError:
+            ioc_common.logit({
+                "level": "EXCEPTION",
+                "message": "Please provide a valid UUID"
+            })
+        else:
+            if count > 1:
+                ioc_common.logit({
+                    "level": "EXCEPTION",
+                    "message": "Flag --count cannot be used with --uuid"
+                })
 
     if name:
         # noinspection Annotator

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -27,7 +27,6 @@ import json
 import operator
 import os
 import subprocess as su
-import uuid
 
 import iocage_lib.ioc_clean as ioc_clean
 import iocage_lib.ioc_common as ioc_common
@@ -574,15 +573,6 @@ class IOCage(object):
         try:
             if count > 1 and not skip_batch:
                 for j in range(1, count + 1):
-                    try:
-                        if _uuid is not None:
-                            uuid.UUID(_uuid, version=4)
-
-                        count_uuid = _uuid  # Is a UUID
-                    except ValueError:
-                        # This will allow named jails to use count
-                        # This can probably be smarter
-                        count_uuid = f"{_uuid}_{j}"
 
                     self.create(
                         release,
@@ -591,7 +581,7 @@ class IOCage(object):
                         pkglist=pkglist,
                         template=template,
                         short=short,
-                        _uuid=count_uuid,
+                        _uuid=f"{_uuid}_{j}" if _uuid else None,
                         basejail=basejail,
                         thickjail=thickjail,
                         empty=empty,


### PR DESCRIPTION
This commit fixes a bug where we were not able to create count jails when a valid uuid was supplied as a name. Apart from that this commit enforces that count flag cannot be used with uuid flag and removes force option from create command as it is not used anywhere.
Ticket: #61551
