### PR TITLE
tkt-61884: Massive refactor of ioc_fstab

### DIFF
--- a/iocage_cli/__init__.py
+++ b/iocage_cli/__init__.py
@@ -84,7 +84,7 @@ class IOCLogger(object):
         self.log_file = os.environ.get("IOCAGE_LOGFILE", "/var/log/iocage.log")
         self.colorize = os.environ.get("IOCAGE_COLOR", "FALSE")
         logger = logging.getLogger("iocage")
-        
+
         if logger.hasHandlers():
             # If we're imported multiple times (like tests) this will prevent
             # a large duplicate flood of text.

--- a/iocage_cli/fstab.py
+++ b/iocage_cli/fstab.py
@@ -60,8 +60,8 @@ def cli(action, fstab_string, jail, header, replace):
 
     if not fstab_string and action != "edit" and action != "list":
         ioc_common.logit({
-            "level": "EXCEPTION",
-            "message": "Please supply a fstab entry or jail!"
+            'level': 'EXCEPTION',
+            'message': 'Please supply an fstab entry or jail!'
         })
 
     # The user will expect to supply a string, the API would prefer these

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -65,7 +65,14 @@ def callback(_log, callback_exception):
             if not os.isatty(sys.stdout.fileno()):
                 raise callback_exception(message)
             else:
+                if not isinstance(message, str) and isinstance(
+                    message,
+                    collections.Iterable
+                ):
+                    message = '\n'.join(message)
+
                 log.error(message)
+
                 if force_raise:
                     raise callback_exception(message)
                 else:

--- a/iocage_lib/ioc_exceptions.py
+++ b/iocage_lib/ioc_exceptions.py
@@ -25,6 +25,19 @@
 import collections
 
 
+class ExceptionWithMsg(Exception):
+    """message attribute will be an iterable if a message is supplied"""
+    def __init__(self, message):
+        if not isinstance(message, str) and not isinstance(
+            message,
+            collections.Iterable
+        ):
+            message = [message]
+
+        self.message = message
+        super().__init__(message)
+
+
 class PoolNotActivated(Exception):
     pass
 
@@ -33,24 +46,12 @@ class JailRunning(Exception):
     pass
 
 
-class CommandFailed(Exception):
-    """message attribute will be an iterable if a message is supplied"""
-    def __init__(self, message):
-        if not isinstance(message, collections.Iterable):
-            message = [message]
-
-        self.message = message
-        super().__init__(message)
+class CommandFailed(ExceptionWithMsg):
+    pass
 
 
-class JailMisconfigured(Exception):
-    """message attribute will be a string if a message is supplied"""
-    def __init__(self, message):
-        if not isinstance(message, str):
-            message = str(message)
-
-        self.message = message
-        super().__init__(message)
+class JailMisconfigured(ExceptionWithMsg):
+    pass
 
 
 class JailCorruptConfiguration(JailMisconfigured):

--- a/iocage_lib/ioc_exceptions.py
+++ b/iocage_lib/ioc_exceptions.py
@@ -60,3 +60,7 @@ class JailCorruptConfiguration(JailMisconfigured):
 
 class JailMissingConfiguration(JailMisconfigured):
     pass
+
+
+class ValidationFailed(ExceptionWithMsg):
+    pass

--- a/iocage_lib/ioc_fstab.py
+++ b/iocage_lib/ioc_fstab.py
@@ -122,8 +122,13 @@ class IOCFstab(object):
         jail_root = f'{self.iocroot}/jails/{self.uuid}/root'
 
         for line in fstab:
-            source, destination, fstype, options, \
-                dump, _pass = line.split()[0:6]
+            try:
+                source, destination, fstype, options, \
+                    dump, _pass = line.split()[0:6]
+            except ValueError:
+                verrors.append(f'Malformed fstab line: {line}')
+                continue
+
             source = pathlib.Path(source)
             missing_root = False
             dest = pathlib.Path(destination)

--- a/iocage_lib/ioc_fstab.py
+++ b/iocage_lib/ioc_fstab.py
@@ -116,16 +116,6 @@ class IOCFstab(object):
             for line in f:
                 yield line.rstrip()
 
-    def __get_fstab_dests_(self):
-        dests = []
-
-        for line in self.fstab:
-            source, destination, fstype, options, \
-                dump, _pass = line.split()[0:6]
-            dests.append(destination)
-
-        return dests
-
     def __validate_fstab__(self, fstab, mode='single'):
         dests = []
         verrors = []


### PR DESCRIPTION
- Remove unused line
- Join multiline error messages with logit
- Create new exception class for inheritance
- Create reusable single instance of fstab
- Validates fstab before loading it now (unless using list, that's for users to spot the issues themselves)
- Check for duplicate entries
- Check if destination exists
- Check if source/destination is a directory
- Check if source/destination is an absolute path
- Check if dump/pass are single proper integers

Ticket: #61884