### PR TITLE
tkt-62046: Use default rc.conf file instead of builtin boilerplate

### DIFF
--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -873,8 +873,9 @@ syslogd_flags="-c -ss"
 ipv6_activate_all_interfaces=\"YES\"
 """
             rc_conf.write_text(rcconf)
-            if not jail_rc_conf.is_file():
-                shutil.copy(str(rc_conf), str(jail_rc_conf))
+
+        if not jail_rc_conf.is_file():
+            shutil.copy(str(rc_conf), str(jail_rc_conf))
 
         if basejail != 'no':
             su.Popen(


### PR DESCRIPTION
This allows the user to customize their rc.conf that is deployed to jails. Important to customize for environments.

Behavior:
- If jail is being created from a template, it will use the templates rc.conf instead of the default_rc.conf. 
- If jail is being created from a RELEASE, it will use the default_rc.conf located in the iocage mountpoint.

- Fix bad sendmail default