### PR TITLE
STABLE: Fix bad default for sendmail and host_hostname

### DIFF
--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -788,7 +788,7 @@ class IOCCreate(object):
                      stdout=su.PIPE).communicate()
         else:
             rcconf = """\
-host_hostname="{hostname}"
+hostname="{hostname}"
 cron_flags="$cron_flags -J 15"
 
 # Disable Sendmail by default

--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -792,7 +792,7 @@ host_hostname="{hostname}"
 cron_flags="$cron_flags -J 15"
 
 # Disable Sendmail by default
-sendmail_enable="NONE"
+sendmail_enable="NO"
 sendmail_submit_enable="NO"
 sendmail_outbound_enable="NO"
 sendmail_msp_queue_enable="NO"


### PR DESCRIPTION
Currently this is leaving it enabled for jails, which is not desired.

FreeNAS Ticket: #62055