### PR TITLE
tkt-63306: Destroy Network related setup on stop (#713) (by sonicaj)

### DIFF
--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -446,9 +446,9 @@ class IOCStart(object):
                     failed_dhcp = True
 
                 if failed_dhcp:
-                    iocage_lib.ioc_stop.IOCStop(self.uuid, self.path,
-                                                self.conf, force=True,
-                                                silent=True)
+                    iocage_lib.ioc_stop.IOCStop(
+                        self.uuid, self.path, self.conf, force=True, silent=True
+                    )
 
                     iocage_lib.ioc_common.logit({
                         "level": "EXCEPTION",


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick 8e7d64dd90f54c12f8d8d7ce7328a1da29902360

This commit changes previous behaviour for iocage where now it tries to destroy network related setup if a jail is stopped with force flag set to true. However, in that case we suppress exceptions if any and move on.
Ticket: #61668