### PR TITLE
tkt-63891: Fix a few issues in extraction/downloading code

### DIFF
--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -61,8 +61,7 @@ class IOCFetch(object):
                  hardened=False,
                  update=True,
                  eol=True,
-                 files=("MANIFEST", "base.txz", "lib32.txz", "doc.txz",
-                        "src.txz"),
+                 files=('MANIFEST', 'base.txz', 'lib32.txz', 'src.txz'),
                  silent=False,
                  callback=None):
         self.pool = iocage_lib.ioc_json.IOCJson().json_get_value("pool")

--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -594,7 +594,6 @@ class IOCFetch(object):
                     },
                     _callback=self.callback,
                     silent=self.silent)
-                missing.append("MANIFEST")
 
             for f in self.files:
                 if f == "MANIFEST":

--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -556,6 +556,13 @@ class IOCFetch(object):
             for _, _, files in os.walk("."):
                 if "MANIFEST" not in files:
                     if self.server == "https://download.freebsd.org":
+                        iocage_lib.ioc_common.logit(
+                            {
+                                'level': 'INFO',
+                                'message': 'MANIFEST missing, downloading one'
+                            },
+                            _callback=self.callback,
+                            silent=self.silent)
                         r = requests.get(
                             f"{self.server}/{self.root_dir}/"
                             f"{self.release}/MANIFEST",
@@ -622,7 +629,7 @@ class IOCFetch(object):
                                         },
                                         _callback=self.callback,
                                         silent=self.silent)
-                    except (FileNotFoundError, KeyError) as err:
+                    except FileNotFoundError:
                         if not _missing:
                             iocage_lib.ioc_common.logit(
                                 {
@@ -642,8 +649,18 @@ class IOCFetch(object):
                                 },
                                 _callback=self.callback,
                                 silent=self.silent)
+                    except KeyError:
+                        iocage_lib.ioc_common.logit(
+                            {
+                                'level': 'WARNING',
+                                'message': f'{f} missing from MANIFEST,'
+                                           ' refusing to extract!'
+                            },
+                            _callback=self.callback,
+                            silent=self.silent)
+                        continue
 
-                if not missing:
+                if not missing and f in _list:
                     iocage_lib.ioc_common.logit(
                         {
                             "level": "INFO",

--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -777,7 +777,7 @@ class IOCFetch(object):
                                 if progress != last_progress:
                                     text = self.update_progress(
                                         progress,
-                                        f'Downloading : {f}',
+                                        f'Downloading: {f}',
                                         elapsed,
                                         chunk_size
                                     )

--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -84,7 +84,7 @@ class IOCFetch(object):
         self.verify = verify
         self.hardened = hardened
         self.files = files
-        self.files_left = list(files).copy()
+        self.files_left = list(files)
         self.update = update
         self.eol = eol
         self.silent = silent
@@ -504,7 +504,7 @@ class IOCFetch(object):
             _callback=self.callback,
             silent=self.silent)
         self.fetch_download(self.files)
-        missing = self.__fetch_check__(self.files)
+        missing_files = self.__fetch_check__(self.files)
         missing_attempt = 0
 
         while True:
@@ -515,21 +515,22 @@ class IOCFetch(object):
                 iocage_lib.ioc_common.logit(
                     {
                         'level': 'EXCEPTION',
-                        'message': 'Max retries exceeded, too many failed'
-                                   ' verifications!'
+                        'message': 'Max retries exceeded, one or more files'
+                                   f' ({", ".join(missing_files)})'
+                                   ' failed checksum verification!'
                     },
                     _callback=self.callback,
                     silent=self.silent)
 
-            _missing = True if missing else False
+            if not missing_files:
+                missing_files = self.files_left
 
-            if not _missing:
-                missing = self.files_left
+            self.fetch_download(missing_files, missing=bool(missing_files))
+            missing_files = self.__fetch_check__(
+                missing_files, _missing=bool(missing_files)
+            )
 
-            self.fetch_download(missing, missing=_missing)
-            missing = self.__fetch_check__(missing, _missing=_missing)
-
-            if missing:
+            if missing_files:
                 missing_attempt += 1
 
         if not self.hardened and self.update:
@@ -596,7 +597,7 @@ class IOCFetch(object):
                         hashes[col[0]] = col[1]
             except FileNotFoundError:
                 if 'MANIFEST' not in self.files:
-                    m_files = ''.join([f"-F {x} " for x in self.files])
+                    m_files = ' '.join([f'-F {x}' for x in self.files])
                     m = f'iocage fetch -r {self.release} -s {self.server}' \
                         f' -F MANIFEST {m_files}'
                     iocage_lib.ioc_common.logit(

--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -583,6 +583,17 @@ class IOCFetch(object):
                         col = line.split("\t")
                         hashes[col[0]] = col[1]
             except FileNotFoundError:
+                m_files = ''.join([f"-F {x} " for x in self.files])
+                m = f'iocage fetch -r {self.release} -s {self.server}' \
+                    f' -F MANIFEST {m_files}'
+                iocage_lib.ioc_common.logit(
+                    {
+                        'level': 'EXCEPTION',
+                        'message': 'MANIFEST missing, refusing to continue!\n'
+                                   f'EXAMPLE COMMAND: {m}'
+                    },
+                    _callback=self.callback,
+                    silent=self.silent)
                 missing.append("MANIFEST")
 
             for f in self.files:

--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -84,6 +84,7 @@ class IOCFetch(object):
         self.verify = verify
         self.hardened = hardened
         self.files = files
+        self.files_left = list(files).copy()
         self.update = update
         self.eol = eol
         self.silent = silent
@@ -504,10 +505,32 @@ class IOCFetch(object):
             silent=self.silent)
         self.fetch_download(self.files)
         missing = self.__fetch_check__(self.files)
+        missing_attempt = 0
 
-        if missing:
-            self.fetch_download(missing, missing=True)
-            self.__fetch_check__(missing, _missing=True)
+        while True:
+            if not self.files_left:
+                break
+
+            if missing_attempt == 4:
+                iocage_lib.ioc_common.logit(
+                    {
+                        'level': 'EXCEPTION',
+                        'message': 'Max retries exceeded, too many failed'
+                                   ' verifications!'
+                    },
+                    _callback=self.callback,
+                    silent=self.silent)
+
+            _missing = True if missing else False
+
+            if not _missing:
+                missing = self.files_left
+
+            self.fetch_download(missing, missing=_missing)
+            missing = self.__fetch_check__(missing, _missing=_missing)
+
+            if missing:
+                missing_attempt += 1
 
         if not self.hardened and self.update:
             self.fetch_update()
@@ -549,6 +572,7 @@ class IOCFetch(object):
         """
         hashes = {}
         missing = []
+        files_left = self.files_left.copy()
 
         if os.path.isdir(f"{self.iocroot}/download/{self.release}"):
             os.chdir(f"{self.iocroot}/download/{self.release}")
@@ -563,19 +587,7 @@ class IOCFetch(object):
                             },
                             _callback=self.callback,
                             silent=self.silent)
-                        r = requests.get(
-                            f"{self.server}/{self.root_dir}/"
-                            f"{self.release}/MANIFEST",
-                            verify=self.verify,
-                            stream=True)
-
-                        status = r.status_code == requests.codes.ok
-
-                        if not status:
-                            r.raise_for_status()
-
-                        with open("MANIFEST", "wb") as txz:
-                            shutil.copyfileobj(r.raw, txz)
+                        self.fetch_download(['MANIFEST'], missing=True)
 
             try:
                 with open("MANIFEST", "r") as _manifest:
@@ -583,20 +595,29 @@ class IOCFetch(object):
                         col = line.split("\t")
                         hashes[col[0]] = col[1]
             except FileNotFoundError:
-                m_files = ''.join([f"-F {x} " for x in self.files])
-                m = f'iocage fetch -r {self.release} -s {self.server}' \
-                    f' -F MANIFEST {m_files}'
-                iocage_lib.ioc_common.logit(
-                    {
-                        'level': 'EXCEPTION',
-                        'message': 'MANIFEST missing, refusing to continue!\n'
-                                   f'EXAMPLE COMMAND: {m}'
-                    },
-                    _callback=self.callback,
-                    silent=self.silent)
+                if 'MANIFEST' not in self.files:
+                    m_files = ''.join([f"-F {x} " for x in self.files])
+                    m = f'iocage fetch -r {self.release} -s {self.server}' \
+                        f' -F MANIFEST {m_files}'
+                    iocage_lib.ioc_common.logit(
+                        {
+                            'level': 'EXCEPTION',
+                            'message': 'MANIFEST missing, refusing to continue'
+                                       f'!\nEXAMPLE COMMAND: {m}'
+                        },
+                        _callback=self.callback,
+                        silent=self.silent)
 
-            for f in self.files:
+                self.fetch_download(['MANIFEST'], missing=True)
+                with open("MANIFEST", "r") as _manifest:
+                    for line in _manifest:
+                        col = line.split("\t")
+                        hashes[col[0]] = col[1]
+
+            for f in files_left:
                 if f == "MANIFEST":
+                    if f in self.files_left:
+                        self.files_left.remove(f)
                     continue
 
                 if self.hardened and f == "lib32.txz":
@@ -628,17 +649,6 @@ class IOCFetch(object):
                                         _callback=self.callback,
                                         silent=self.silent)
                                     missing.append(f)
-                                else:
-                                    iocage_lib.ioc_common.logit(
-                                        {
-                                            "level":
-                                            "EXCEPTION",
-                                            "message":
-                                            "Too many failed"
-                                            " verifications!"
-                                        },
-                                        _callback=self.callback,
-                                        silent=self.silent)
                     except FileNotFoundError:
                         if not _missing:
                             iocage_lib.ioc_common.logit(
@@ -683,6 +693,9 @@ class IOCFetch(object):
                         self.fetch_extract(f)
                     except Exception:
                         raise
+
+                    if f in self.files_left:
+                        self.files_left.remove(f)
 
             return missing
 

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -946,11 +946,10 @@ class IOCage(object):
         if not _list:
             if not kwargs["files"]:
                 if arch == "arm64":
-                    kwargs["files"] = ("MANIFEST", "base.txz", "doc.txz",
-                                       "src.txz")
+                    kwargs["files"] = ("MANIFEST", "base.txz", "src.txz")
                 else:
                     kwargs["files"] = ("MANIFEST", "base.txz", "lib32.txz",
-                                       "doc.txz", "src.txz")
+                                       "src.txz")
 
             if "HBSD" in freebsd_version:
                 if kwargs["server"] == "download.freebsd.org":


### PR DESCRIPTION
- Remove doc.txz from default files
- Inform user we are downloading the MANIFEST if missing and using the default FreeBSD server
- No longer try to extract/verify files that are missing from the MANIFEST. This avoids the terrible behavior of then trying to redownload that file and reverify, which would only fail.
- No longer extract all files when a redownload of a dist has happened. This was exacerbated by the above issue.
- Don't extract if the user doesn't have a MANIFEST and uses custom server
  Give the user a sane example that will work, not taking into account if they supplied other flags like --noupdate and such.
-Fix a few more remaining fetch bugs
    A couple other long standing issues finally squashed:
    - When a file was missing and extracted, no others would continue extracting
    - Missing routine only ran once, now runs 3 times
    - MANIFESTs that were downloaded weren't read back in  for the hashes, resulting in a second required run.
- Remove extra space in downloading fetch message

FreeNAS Ticket: #63891