### PR TITLE
tkt-64647: Fix mismatching RELEASEs being fetched, and a couple other bugs (by skarekrow)

### DIFF
--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -1210,8 +1210,8 @@ fingerprint: {fingerprint}
 
     def __fetch_release__(self, release):
         """Will call fetch to get the new RELEASE the plugin will rely on"""
-        iocage_lib.ioc_fetch.IOCFetch(
-            release, silent=self.silent).fetch_release()
+        fetch_args = {'release': release}
+        iocage_lib.iocage.IOCage(silent=self.silent).fetch(**fetch_args)
 
     def __clone_repo(self, repo_url, destination):
         """

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -884,8 +884,8 @@ class IOCage(object):
         arch = os.uname()[4]
 
         if not _list:
-            if not kwargs["files"]:
-                if arch == "arm64":
+            if not kwargs.get('files', None):
+                if arch == 'arm64':
                     kwargs["files"] = ("MANIFEST", "base.txz", "doc.txz",
                                        "src.txz")
                 else:


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick 946056a9af10eeda4ff97f8c551865da83e5547e

Noted by @jsegaert

- Use the right interface for fetching instead of internal plumbing
- Fix bad variable usage
- Fix a couple other exceptions that could occur with the fetch interface

FreeNAS Ticket: #64638