### PR TITLE
tkt-79311: Naming conflicts

### DIFF
--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -935,36 +935,36 @@ class IOCJson(object):
             release = release.rsplit("-p", 1)[0]
             cloned_release = conf.get("cloned_release", "LEGACY_JAIL")
 
-        freebsd_version = pathlib.Path(
-            f'{iocroot}/releases/{release}/root/bin/freebsd-version'
-        )
-        if not freebsd_version.is_file():
-            try:
-                if template == 'yes':
-                    freebsd_version = pathlib.Path(
-                        f'{iocroot}/templates/'
-                        f"{conf['host_hostuuid']}/root/bin/freebsd-version"
-                    )
-                else:
-                    temp_uuid = self.location.rsplit('/', 1)[-1]
-                    freebsd_version = pathlib.Path(
-                        f'{iocroot}/jails/{temp_uuid}/root/bin/'
-                        'freebsd-version'
-                    )
-                if not freebsd_version.is_file():
-                    iocage_lib.ioc_common.logit(
-                        {
-                            'level': 'EXCEPTION',
-                            'message': 'freebsd-version could not be found at'
-                            f' {freebsd_version}'
-                        }
-                    )
-            except KeyError:
-                # At this point it should be a real misconfigured jail
-                uuid = self.location.rsplit('/', 1)[-1]
-                raise RuntimeError('Configuration is missing!'
-                                   f' Please destroy {uuid} and recreate'
-                                   ' it.')
+            uuid = self.location.rsplit('/', 1)[-1]
+            freebsd_version = pathlib.Path(
+                f'{iocroot}/releases/{release}/root/bin/freebsd-version'
+            )
+            if not freebsd_version.is_file():
+                try:
+                    if template == 'yes':
+                        freebsd_version = pathlib.Path(
+                            f'{iocroot}/templates/'
+                            f"{conf['host_hostuuid']}/root/bin/freebsd-version"
+                        )
+                    else:
+                        temp_uuid = self.location.rsplit('/', 1)[-1]
+                        freebsd_version = pathlib.Path(
+                            f'{iocroot}/jails/{temp_uuid}/root/bin/'
+                            'freebsd-version'
+                        )
+                    if not freebsd_version.is_file():
+                        iocage_lib.ioc_common.logit(
+                            {
+                                'level': 'EXCEPTION',
+                                'message': 'freebsd-version could not be found at'
+                                f' {freebsd_version}'
+                            }
+                        )
+                except KeyError:
+                    # At this point it should be a real misconfigured jail
+                    raise RuntimeError('Configuration is missing!'
+                                       f' Please destroy {uuid} and recreate'
+                                       ' it.')
 
             if release[:4].endswith("-"):
                 # 9.3-RELEASE and under don't actually have this binary.


### PR DESCRIPTION
This commit resolves two naming conflicts where we used a variable before assigning it.
Ticket: #79311
