### PR TITLE
tkt-83291: Safety check for mountpoint prop (by sonicaj)

### DIFF
--- a/iocage_lib/ioc_list.py
+++ b/iocage_lib/ioc_list.py
@@ -80,7 +80,18 @@ class IOCList(object):
 
             for jail in ds:
                 uuid = jail.name.rsplit("/", 1)[-1]
-                jails[uuid] = jail.properties["mountpoint"].value
+                try:
+                    jails[uuid] = jail.properties["mountpoint"].value
+                except KeyError:
+                    iocage_lib.ioc_common.logit(
+                        {
+                            'level': 'ERROR',
+                            'message': f'{jail.name} mountpoint is '
+                            'misconfigured. Please correct this.'
+                        },
+                        _callback=self.callback,
+                        silent=self.silent
+                    )
 
             template_datasets = self.zfs.get_dataset(
                 f"{self.pool}/iocage/templates")
@@ -101,7 +112,19 @@ class IOCList(object):
         jail_list = []
 
         for jail in jails:
-            mountpoint = jail.properties["mountpoint"].value
+            try:
+                mountpoint = jail.properties["mountpoint"].value
+            except KeyError:
+                iocage_lib.ioc_common.logit(
+                    {
+                        'level': 'ERROR',
+                        'message': f'{jail.name} mountpoint is misconfigured. '
+                        'Please correct this.'
+                    },
+                    _callback=self.callback,
+                    silent=self.silent
+                )
+                continue
 
             try:
                 with open(f"{mountpoint}/config.json", "r") as loc:
@@ -161,7 +184,20 @@ class IOCList(object):
         jail_list = []
 
         for jail in jails:
-            mountpoint = jail.properties["mountpoint"].value
+            try:
+                mountpoint = jail.properties["mountpoint"].value
+            except KeyError:
+                iocage_lib.ioc_common.logit(
+                    {
+                        'level': 'ERROR',
+                        'message': f'{jail.name} mountpoint is misconfigured. '
+                        'Please correct this.'
+                    },
+                    _callback=self.callback,
+                    silent=self.silent
+                )
+                continue
+
             try:
                 conf = iocage_lib.ioc_json.IOCJson(mountpoint).json_get_value(
                     'all'


### PR DESCRIPTION
This commit adds a safety check for ensuring that if a user has made a dataset/zvol under templates/jails dataset, we raise a warning for that while listing jails/templates instead of raising a traceback.
Ticket: #81498
