### PR TITLE
NAS-101270 / 11.2 / Replace old fstab locations  (by skarekrow)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ venv-*/
 .pytest_cache/
 
 nvim\.core
+/tags

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -144,6 +144,17 @@ class IOCStart(object):
         prop_missing = False
         prop_missing_msgs = []
 
+        fstab_list = []
+        with open(f'{self.iocroot}/jails/{self.uuid}/fstab', 'r') as _fstab:
+            for line in _fstab.readlines():
+                line = line.rsplit("#")[0].rstrip()
+                fstab_list.append(line)
+
+        iocage_lib.ioc_fstab.IOCFstab(
+            self.uuid,
+            'list'
+        ).__validate_fstab__(fstab_list, 'all')
+        
         if dhcp == "on":
             if bpf != "yes":
                 prop_missing_msgs.append(


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 67ceb4b6aa08d1804abbaf97ee2ae40311f6b19e
    git cherry-pick -x 5e422e7a58d8d7f2665020b6e27837e4ff9fbcf4
    git cherry-pick -x f0aa5b5e9abe9f698166b81a1137292e4837c8e1
    git cherry-pick -x a6ddad0857037b62585d9a3a1de83079b678513b
    git cherry-pick -x 3c9db255e90abbe7c58584055e3523014d493a76

This will replace the old iocage mountpoints (/mnt/iocage or /iocage) with the current structure (/mnt/POOL/iocage or /POOL/iocage) if the new source/destination directory exist.

This also corrects an issue with replacing an index not writing new line endings. We check these during all fstab operations except list, and during start.

NAS-101270