### PR TITLE
NAS-101365 / 11.2 / Proxy support for iocage (by sonicaj)

### DIFF
--- a/iocage_cli/create.py
+++ b/iocage_cli/create.py
@@ -81,9 +81,11 @@ def validate_count(ctx, param, value):
                    " 36.")
 @click.option("--force", "-f", is_flag=True, default=False,
               help="Skip the interactive question.")
+@click.option('--proxy', '-S', default=None,
+              help='Provide proxy to use for creating jail')
 @click.argument("props", nargs=-1)
 def cli(release, template, count, props, pkglist, basejail, thickjail, empty,
-        short, name, _uuid, force):
+        short, name, _uuid, force, proxy):
 
     if name:
         # noinspection Annotator
@@ -97,6 +99,12 @@ def cli(release, template, count, props, pkglist, basejail, thickjail, empty,
 
         # At this point we don't care
         _uuid = name
+
+    if proxy:
+        os.environ.update({
+            'http_proxy': proxy,
+            'https_proxy': proxy
+        })
 
     if release and "=" in release:
         ioc_common.logit({

--- a/iocage_cli/fetch.py
+++ b/iocage_cli/fetch.py
@@ -26,6 +26,8 @@ import click
 import iocage_lib.ioc_common as ioc_common
 import iocage_lib.iocage as ioc
 
+import os
+
 __rootcmd__ = True
 
 
@@ -97,6 +99,8 @@ def validate_count(ctx, param, value):
               help="Lists only official plugins.")
 @click.option("--branch", default=None,
               help="Select a different plugin branch (for development)")
+@click.option('--proxy', '-S', default=None,
+              help='Provide proxy to use for creating jail')
 def cli(**kwargs):
     """CLI command that calls fetch_release()"""
     release = kwargs.get("release", None)
@@ -107,6 +111,13 @@ def cli(**kwargs):
                 "level": "EXCEPTION",
                 "message": "Please supply a --name for plugin-file."
             })
+
+    proxy = kwargs.pop('proxy')
+    if proxy:
+        os.environ.update({
+            'http_proxy': proxy,
+            'https_proxy': proxy
+        })
 
     if release is not None:
         if release.lower() == "latest":

--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -716,7 +716,13 @@ class IOCCreate(object):
                     _callback=self.callback)
 
         # We will have mismatched ABI errors from earlier, this is to be safe.
-        pkg_env = {"ASSUME_ALWAYS_YES": "yes"}
+        pkg_env = {
+            **{
+                k: os.environ.get(k)
+                for k in ['http_proxy', 'https_proxy'] if os.environ.get(k)
+            },
+            'ASSUME_ALWAYS_YES': 'yes'
+        }
         cmd = ("/usr/local/sbin/pkg-static", "upgrade", "-f", "-q", "-y")
         pkg_upgrade, pkgup_stderr, pkgup_err = iocage_lib.ioc_exec.IOCExec(
             cmd, jail_uuid, location, plugin=self.plugin,

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -541,7 +541,13 @@ fingerprint: {fingerprint}
             ip = f"{out.splitlines()[2].split()[1]}"
             os.environ["IOCAGE_PLUGIN_IP"] = ip
 
-        plugin_env = {"IOCAGE_PLUGIN_IP": ip.rsplit(',')[0]}
+        plugin_env = {
+            **{
+                k: os.environ.get(k)
+                for k in ['http_proxy', 'https_proxy'] if os.environ.get(k)
+            },
+            'IOCAGE_PLUGIN_IP': ip.rsplit(',')[0]
+        }
 
         # We need to pipe from tar to the root of the jail.
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x fdb5ac0449f560b14a53edb8d53bd10ec45197b5

This commit adds proxy support for iocage making sure that proxy provided by cli or set in the environment if library is being used directly is respected.
Ticket: NAS-101365

Note: DNS lookups DONOT respect the proxy, so a proper firewall should be configured - other communications, fetching, installing packages etc obey the proxy as desired