### PR TITLE
NAS-101623 / 11.2 / Replace underscores in hostname

### DIFF
--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -575,7 +575,7 @@ class IOCCreate(object):
 
         # Unique jail properties, they will be overridden by user supplied
         # values.
-        jail_props["host_hostname"] = jail_uuid
+        jail_props["host_hostname"] = jail_uuid.replace('_', '-')
         jail_props["host_hostuuid"] = jail_uuid
         jail_props["hostid_strict_check"] = "off"
         jail_props["release"] = release


### PR DESCRIPTION
This is a “backport” of #65610

NAS-101623

Signed-off-by: Brandon Schneider <brandon@ixsystems.com>