### PR TITLE
NAS-102611 / 11.2 / Ensure default configuration existence

### DIFF
--- a/iocage_lib/ioc_list.py
+++ b/iocage_lib/ioc_list.py
@@ -60,6 +60,9 @@ class IOCList(object):
     def list_datasets(self):
         """Lists the datasets of given type."""
 
+        # We want to ensure that `defaults.json` is always present
+        iocage_lib.ioc_json.IOCJson().json_check_default_config()
+
         if self.list_type == "all" or self.list_type == "uuid":
             ds = self.zfs.get_dataset(f"{self.pool}/iocage/jails").children
         elif self.list_type == "base":


### PR DESCRIPTION
This commit introduces changes which makes sure that in cases when default configuration is absent and the jail's configuration is corrupt too, we don't raise a traceback and create the default configuration file instead also making sure jails are listed correctly as corrupt.