### PR TITLE
Support multiple NAT prefixes when using pf firewall

### DIFF
--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -1553,6 +1553,8 @@ class IOCStart(object):
                 line = line.rstrip()
                 if line.startswith('rdr') and ip4_addr not in line:
                     rules.append(line)
+                if line.startswith('nat') and nat_network not in line:
+                    rules.append(line)
 
             f.seek(0)
             for rule in rules:


### PR DESCRIPTION
Ref NAS-102695, patch to allow the pf firewall to properly support multiple nat_prefix zones.
Without this patch, any nat rules will be obliterated from the list when starting a jail and using the pf firewall.
