### PR TITLE
Drop dulwich dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ click>=6.7
 texttable>=1.2.1
 requests>=2.18.4
 coloredlogs>=9.0
-dulwich>=0.18.6
+GitPython>=2.1.11
 netifaces>=0.10.6

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'dulwich>=0.18.6',
+        'GitPython>=2.1.11',
         'netifaces>=0.10.6',
         'libzfs'
     ],


### PR DESCRIPTION
This commit drops dulwich dependency and replaces it's usages with git python instead.
