### PR TITLE
Make sure we don't stop/start jail unnecessarily

### DIFF
--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -592,12 +592,13 @@ class IOCCreate(object):
         Takes a list of pkg's to install into the target jail. The resolver
         property is required for pkg to have network access.
         """
+        started = False
         status, jid = iocage_lib.ioc_list.IOCList().list_get_jid(jail_uuid)
 
         if not status:
             iocage_lib.ioc_start.IOCStart(jail_uuid, location, config,
                                           silent=True)
-            status, jid = iocage_lib.ioc_list.IOCList().list_get_jid(jail_uuid)
+            started, jid = iocage_lib.ioc_list.IOCList().list_get_jid(jail_uuid)
 
         if repo:
             r = re.match('(https?(://)?)?([^/]+)', repo)
@@ -791,9 +792,7 @@ class IOCCreate(object):
                         pkg_err_list.append(pkg_err_msg)
                     break
 
-        os.remove(f"{location}/root/etc/resolv.conf")
-
-        if status:
+        if started:
             iocage_lib.ioc_stop.IOCStop(jail_uuid, location, config,
                                         silent=True)
 

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -509,7 +509,9 @@ fingerprint: {fingerprint}
 
     def __fetch_plugin_post_install__(self, conf, _conf, jaildir, uuid):
         """Fetches the users artifact and runs the post install"""
-        iocage_lib.ioc_start.IOCStart(uuid, jaildir, _conf, silent=True)
+        status, jid = iocage_lib.ioc_list.IOCList().list_get_jid(uuid)
+        if not status:
+            iocage_lib.ioc_start.IOCStart(uuid, jaildir, _conf, silent=True)
 
         ip4 = _conf["ip4_addr"]
         if '|' in ip4:


### PR DESCRIPTION
This commit makes sure that we don't stop/start a jail unnecessarily when installing a package. It is only stopped if it was started by iocage during pkg installation phase.
Also this commit removes a usage where we removed resolv.conf, i am unsure why we were doing that here at all but that is likely going to cause issues if the jail is already running and the user expects his resolv.conf to be there.