### PR TITLE
NAS-103581 / 11.3 / Introduce locks for iocage cache (by sonicaj)

### DIFF
--- a/iocage_lib/cache.py
+++ b/iocage_lib/cache.py
@@ -1,24 +1,32 @@
 from iocage_lib.zfs import all_properties
 
+import threading
+
 
 class Cache:
+
+    cache_lock = threading.Lock()
+
     def __init__(self):
         self.dataset_data = self.pool_data = None
 
     @property
     def datasets(self):
-        if not self.dataset_data:
-            self.dataset_data = all_properties()
-        return self.dataset_data
+        with self.cache_lock:
+            if not self.dataset_data:
+                self.dataset_data = all_properties()
+            return self.dataset_data
 
     @property
     def pools(self):
-        if not self.pool_data:
-            self.pool_data = all_properties(resource_type='zpool')
-        return self.pool_data
+        with self.cache_lock:
+            if not self.pool_data:
+                self.pool_data = all_properties(resource_type='zpool')
+            return self.pool_data
 
     def reset(self):
-        self.dataset_data = self.pool_data = None
+        with self.cache_lock:
+            self.dataset_data = self.pool_data = None
 
 
 cache = Cache()


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 5b327274a7cb0a350e015d953d819af525102c07

This commit introduces locks for iocage cache which ensure that when iocage's api is being used, it's safe from cache.reset and cache.datasets/pools simultaneous calls
