### PR TITLE
NAS-103827 / 11.2 / Allow users to use higher minor version number jails

### DIFF
--- a/iocage_cli/create.py
+++ b/iocage_cli/create.py
@@ -108,7 +108,7 @@ def cli(release, template, count, props, pkglist, basejail, thickjail, empty,
 
     if release:
         try:
-            ioc_common.check_release_newer(release)
+            ioc_common.check_release_newer(release, major_only=True)
         except ValueError:
             # We're assuming they understand the implications of a custom
             # scheme
@@ -117,7 +117,7 @@ def cli(release, template, count, props, pkglist, basejail, thickjail, empty,
             _release = ioc_common.get_jail_freebsd_version(path, release)
 
             try:
-                ioc_common.check_release_newer(_release)
+                ioc_common.check_release_newer(_release, major_only=True)
             except ValueError:
                 # We tried
                 pass

--- a/iocage_cli/fetch.py
+++ b/iocage_cli/fetch.py
@@ -122,6 +122,6 @@ def cli(**kwargs):
             })
 
         if not _file:
-            ioc_common.check_release_newer(release)
+            ioc_common.check_release_newer(release, major_only=True)
 
     ioc.IOCage().fetch(**kwargs)

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -638,15 +638,15 @@ def get_host_release():
     return release
 
 
-def check_release_newer(release, callback=None, silent=False):
+def check_release_newer(release, callback=None, silent=False, major_only=False):
     """Checks if the host RELEASE is greater than the target release"""
     host_release = get_host_release()
 
     if host_release == "Not a RELEASE":
         return
 
-    h_float = float(str(host_release).rsplit("-")[0])
-    r_float = float(str(release).rsplit("-")[0])
+    h_float = float(str(host_release).rsplit('.' if major_only else '-')[0])
+    r_float = float(str(release).rsplit('.' if major_only else '-')[0])
 
     if h_float < r_float:
         logit(

--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -168,7 +168,7 @@ class IOCFetch(object):
         try:
             self.release = releases[int(self.release)]
             iocage_lib.ioc_common.check_release_newer(
-                self.release, self.callback, self.silent)
+                self.release, self.callback, self.silent, major_only=True)
         except IndexError:
             # Time to print the list again
 

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -287,7 +287,7 @@ class IOCPlugin(object):
 
             if not os.path.isdir(f"{self.iocroot}/releases/{self.release}"):
                 iocage_lib.ioc_common.check_release_newer(
-                    self.release, self.callback, self.silent)
+                    self.release, self.callback, self.silent, major_only=True)
                 self.__fetch_release__(self.release)
 
         if conf["release"][:4].endswith("-"):
@@ -295,7 +295,7 @@ class IOCPlugin(object):
             release = conf["release"]
         else:
             iocage_lib.ioc_common.check_release_newer(
-                self.release, self.callback, self.silent)
+                self.release, self.callback, self.silent, major_only=True)
 
             try:
                 with open(freebsd_version, "r") as r:
@@ -1024,7 +1024,7 @@ fingerprint: {fingerprint}
         self.__check_manifest__(plugin_conf)
         plugin_release = plugin_conf["release"]
         iocage_lib.ioc_common.check_release_newer(
-            plugin_release, self.callback, self.silent)
+            plugin_release, self.callback, self.silent, major_only=True)
         release_p = pathlib.Path(f"{self.iocroot}/releases/{plugin_release}")
 
         if not release_p.exists():

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1617,24 +1617,12 @@ class IOCage(object):
         else:
             uuid, path = self.__check_jail_existence__()
             conf = ioc_json.IOCJson(path, silent=self.silent).json_load()
-            host_release = float(os.uname()[2].rsplit("-", 1)[0].rsplit("-",
-                                                                        1)[0])
             release = conf["release"]
 
             if release != "EMPTY":
                 release = float(release.rsplit("-", 1)[0].rsplit("-", 1)[0])
 
-                if host_release < release:
-                    ioc_common.logit(
-                        {
-                            "level":
-                            "EXCEPTION",
-                            "message":
-                            f"\nHost: {host_release} is not greater than"
-                            f" jail: {release}\nThis is unsupported."
-                        },
-                        _callback=self.callback,
-                        silent=self.silent)
+                ioc_common.check_release_newer(release, major_only=True)
 
             err, msg = self.__check_jail_type__(conf["type"], uuid)
             depends = conf["depends"].split()
@@ -1766,19 +1754,8 @@ class IOCage(object):
 
     def upgrade(self, release):
         if release is not None:
-            host_release = float(os.uname()[2].rsplit("-", 1)[0].rsplit(
-                "-", 1)[0])
             _release = release.rsplit("-", 1)[0].rsplit("-", 1)[0]
-            _release = float(_release)
-
-            if host_release < _release:
-                ioc_common.logit({
-                    "level":
-                    "EXCEPTION",
-                    "message":
-                    f"\nHost: {host_release} is not greater than"
-                    f" target: {_release}\nThis is unsupported."
-                })
+            ioc_common.check_release_newer(_release, major_only=True)
 
         uuid, path = self.__check_jail_existence__()
         root_path = f"{path}/root"


### PR DESCRIPTION
This PR introduces changes which allow user to use higher minor version number jails. This is allowed by FreeBSD and is okay to do so.