### PR TITLE
NAS-104875 / 11.3 / Only update release property on update of jails (by sonicaj)

### DIFF
--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -950,19 +950,20 @@ class IOCFetch:
 
                     if not cli:
                         for jail, path in jails.items():
-                            _json = iocage_lib.ioc_json.IOCJson(path)
+                            _json = iocage_lib.ioc_json.IOCJson(
+                                path, cli=False
+                            )
                             props = _json.json_get_value('all')
 
                             if props['basejail'] and self.release.rsplit(
                                 '-', 1
                             )[0] in props['release']:
-                                props['release'] = new_release
-                                _json.json_write(props)
+                                _json.json_set_value(f'release={new_release}')
                     else:
-                        _json = iocage_lib.ioc_json.IOCJson(jails[uuid])
-                        props = _json.json_get_value('all')
-                        props['release'] = new_release
-                        _json.json_write(props)
+                        _json = iocage_lib.ioc_json.IOCJson(
+                            jails[uuid], cli=False
+                        )
+                        _json.json_set_value(f'release={new_release}')
 
             if self.verify:
                 # tmp only exists if they verify SSL certs


### PR DESCRIPTION
This commit fixes an issue where iocage updated the complete configuration of jails on update for updating release property. This results in undesired behaviour with jails having partial configuration resulting in complete configuration and some properties are different when jail is running, i.e devfs_ruleset, that is changed as well.