### PR TITLE
NAS-104894 / 12.0 / Use plugin manfiest names for determining plugin name

### DIFF
--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -683,19 +683,18 @@ class IOCConfiguration:
                         pass
                     else:
                         if plugin_data.get('name'):
-                            conf['plugin_name'] = plugin_data['name'].lower()
-                            # If this happens, we want to rename the
-                            # json file so it can be detected by iocage
-                            if plugin_data['name'] != json_files[0].rstrip(
-                                '.json'
-                            ):
-                                shutil.move(
-                                    os.path.join(jail_path, json_files[0]),
-                                    os.path.join(
-                                        jail_path,
-                                        f'{plugin_data["name"].lower()}.json'
-                                    )
-                                )
+                            # If the json file has a name entry, we assume
+                            # that the json file in question is the plugin
+                            # manifest and we use the json file's name
+                            # as the plugin name. Motivation is that most
+                            # if not all have same plugin entries as their
+                            # manifest names, however some plugins like plex
+                            # have a different plugin name in their manifest,
+                            # a short one which causes issues if the user
+                            # tries to upgrade.
+                            conf['plugin_name'] = json_files[0].rsplit(
+                                '.json', 1
+                            )[0]
 
             # This is our last resort - if above strategy didn't work,
             # let's use host_hostuuid in this case


### PR DESCRIPTION
This commit introduces changes to use plugin manifest name to determine plugin name instead of using the name entry in the manifest because some plugins might have a different name entry then the manifest file name which so far all plugins have similar to what they have in INDEX.
