### PR TITLE
NAS-104846 / 11.3 / Listing Plugin Fixes (by sonicaj)

### DIFF
--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -625,6 +625,10 @@ class IOCFetch:
                             },
                             _callback=self.callback,
                             silent=self.silent)
+                        if f == 'doc.txz':
+                            # some releases might not have it,
+                            # it is safe to skip
+                            self.files_left.remove(f)
                         continue
 
                 if not missing and f in _list:

--- a/iocage_lib/ioc_list.py
+++ b/iocage_lib/ioc_list.py
@@ -488,12 +488,54 @@ class IOCList(object):
                             git_repository=conf['plugin_repository']
                         )
                         if not os.path.exists(repo_obj.git_destination):
-                            repo_obj.pull_clone_git_repo()
-                        with open(
-                            os.path.join(repo_obj.git_destination, 'INDEX')
-                        ) as f:
-                            plugin_index_data[conf['plugin_repository']] = \
-                                json.loads(f.read())
+                            try:
+                                repo_obj.pull_clone_git_repo()
+                            except Exception as e:
+                                iocage_lib.ioc_common.logit(
+                                    {
+                                        'level': 'ERROR',
+                                        'message':
+                                            'Failed to clone '
+                                            f'{conf["plugin_repository"]} '
+                                            f'for {uuid_full}: {e}'
+                                    },
+                                    _callback=self.callback,
+                                    silent=self.silent
+                                )
+                        index_path = os.path.join(
+                            repo_obj.git_destination, 'INDEX'
+                        )
+                        if not os.path.exists(index_path):
+                            iocage_lib.ioc_common.logit(
+                                {
+                                    'level': 'ERROR',
+                                    'message':
+                                        f'{index_path} does not exist '
+                                        f'for {uuid_full} plugin.'
+                                },
+                                _callback=self.callback,
+                                silent=self.silent
+                            )
+                            plugin_index_data[
+                                conf['plugin_repository']
+                            ] = {}
+                        else:
+                            with open(index_path) as f:
+                                plugin_index_data[
+                                    conf['plugin_repository']
+                                ] = json.loads(f.read())
+                    elif not plugin_index_data[conf['plugin_repository']]:
+                        iocage_lib.ioc_common.logit(
+                            {
+                                'level': 'ERROR',
+                                'message':
+                                    'Unable to retrieve INDEX from '
+                                    f'{conf["plugin_repository"]} for '
+                                    f'{uuid_full}'
+                            },
+                            _callback=self.callback,
+                            silent=self.silent
+                        )
 
                     index_plugin_conf = plugin_index_data[
                         conf['plugin_repository']

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -201,13 +201,17 @@ class IOCPlugin(object):
             index = json.loads(f.read())
 
         for plugin in index:
+            plugin_manifest_path = os.path.join(
+                plugin_index_path, index[plugin]['MANIFEST']
+            )
+            if not os.path.exists(plugin_manifest_path):
+                continue
+
             plugin_index[plugin] = {
                 'primary_pkg': index[plugin].get('primary_pkg'),
                 'category': index[plugin].get('category'),
             }
-            with open(
-                os.path.join(plugin_index_path, index[plugin]['MANIFEST']), 'r'
-            ) as f:
+            with open(plugin_manifest_path, 'r') as f:
                 plugin_index[plugin].update(json.loads(f.read()))
 
         return plugin_index

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -192,12 +192,14 @@ class IOCPlugin(object):
 
     @staticmethod
     def retrieve_plugin_index_data(plugin_index_path):
-        with open(
-            os.path.join(plugin_index_path, 'INDEX'), 'r'
-        ) as f:
+        plugin_index = {}
+        index_path = os.path.join(plugin_index_path, 'INDEX')
+        if not os.path.exists(index_path):
+            return plugin_index
+
+        with open(index_path, 'r') as f:
             index = json.loads(f.read())
 
-        plugin_index = {}
         for plugin in index:
             plugin_index[plugin] = {
                 'primary_pkg': index[plugin].get('primary_pkg'),
@@ -860,8 +862,22 @@ fingerprint: {fingerprint}
     ):
         self.pull_clone_git_repo()
 
-        with open(os.path.join(self.git_destination, 'INDEX'), 'r') as plugins:
-            plugins = json.load(plugins)
+        index_path = os.path.join(self.git_destination, 'INDEX')
+        if not os.path.exists(index_path):
+            # Gracefully handle index not existing bit
+            iocage_lib.ioc_common.logit(
+                {
+                    'level': 'EXCEPTION',
+                    'message': 'Unable to retrieve INDEX of '
+                               f'{self.git_destination} at '
+                               f'{index_path}.'
+                },
+                _callback=self.callback,
+                silent=self.silent
+            )
+        else:
+            with open(index_path, 'r') as plugins:
+                plugins = json.load(plugins)
 
         if index_only:
             return plugins


### PR DESCRIPTION
This PR introduces following changes:

1) If we are unable to fetch a plugin's data from it's repository, we shouldn't error out and still list plugins which are fine. This is fixed in this.
2) Make skipping doc.txz okay when fetching a release as some release might not have it and the user still might have specified his/her desire for it.
3) Gracefully raise exception if INDEX does not exist for certain plugin repositories.