### PR TITLE
NAS-105538 / 12.0 / Make sure mac_prefix is valid (by sonicaj)

### DIFF
--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -580,12 +580,19 @@ class IOCConfiguration:
             # Helps avoid clashes with other systems in the network
             mac_prefix = default_mac[0]['addr'].replace(':', '')[:6]
 
-            return mac_prefix
         except KeyError:
             # They don't have a default gateway, opting for generation of mac
             mac = random.randint(0x00, 0xfffff)
 
-            return f'{mac:06x}'
+            mac_prefix = f'{mac:06x}'
+
+    @staticmethod
+    def validate_mac_prefix(mac_prefix):
+        valid = len(mac_prefix) == 6
+        if valid:
+            binary = format(int(mac_prefix, 16), '024b')
+            valid = binary[7] == '0' and binary[6] == '1'
+        return valid
 
     def json_write(self, data, _file="/config.json", defaults=False):
         """Write a JSON file at the location given with supplied data."""

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -593,6 +593,9 @@ class IOCConfiguration:
         # that this mac is being used in a local network which we set it
         # always.
         if not IOCConfiguration.validate_mac_prefix(mac_prefix):
+            # First and second bits in the first byte will be at
+            # 7th and 6th indexes respectively as networks are
+            # MSB-LTR ordered
             binary = list(format(int(mac_prefix, 16), '024b'))
             binary[6] = '1'
             binary[7] = '0'
@@ -2443,14 +2446,14 @@ class IOCJson(IOCConfiguration):
                         iocage_lib.ioc_common.logit(
                             {
                                 'level': 'EXCEPTION',
-                                'message': 'Please specify a valid mac_prefix'
-                                           'which contains any of '
-                                           'the following letters as a '
-                                           'second character from the left '
-                                           'side: "2,6,A,E".'
-                            }
+                                'message': 'Invalid mac_prefix. Must match '
+                                           '`?X????` where ? can be any '
+                                           'valid hex digit (0-9, A-F) and '
+                                           'X is one of 2, 6, A or E.'
+                            },
+                            _callback=self.callback,
+                            silent=self.silent
                         )
-
                 return value, conf
             else:
                 err = f"{value} is not a valid value for {key}.\n"

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -589,7 +589,7 @@ class IOCConfiguration:
         # Reason for this change is that the first bit in the first byte of
         # mac address dictates unicast/multicast address. In case of
         # multicast address, bridge does not learn from such addresses.
-        # So we make sure that we have it unset and the sixth bit indicates
+        # So we make sure that we have it unset and the second bit indicates
         # that this mac is being used in a local network which we set it
         # always.
         if not IOCConfiguration.validate_mac_prefix(mac_prefix):
@@ -2435,6 +2435,20 @@ class IOCJson(IOCConfiguration):
                             _callback=self.callback,
                             silent=self.silent,
                             exception=ioc_exceptions.ValidationFailed
+                        )
+                elif key == 'mac_prefix':
+                    # Invalid letters - 0,1,3,4,5,7,8,9,B,C,D,F
+                    # Valid letters - 2,6,A,E
+                    if not self.validate_mac_prefix(value):
+                        iocage_lib.ioc_common.logit(
+                            {
+                                'level': 'EXCEPTION',
+                                'message': 'Please specify a valid mac_prefix'
+                                           'which contains any of '
+                                           'the following letters as a '
+                                           'second character from the left '
+                                           'side: "2,6,A,E".'
+                            }
                         )
 
                 return value, conf

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -586,6 +586,20 @@ class IOCConfiguration:
 
             mac_prefix = f'{mac:06x}'
 
+        # Reason for this change is that the first bit in the first byte of
+        # mac address dictates unicast/multicast address. In case of
+        # multicast address, bridge does not learn from such addresses.
+        # So we make sure that we have it unset and the sixth bit indicates
+        # that this mac is being used in a local network which we set it
+        # always.
+        if not IOCConfiguration.validate_mac_prefix(mac_prefix):
+            binary = list(format(int(mac_prefix, 16), '024b'))
+            binary[6] = '1'
+            binary[7] = '0'
+            mac_prefix = format(int(''.join(binary), 2), '06x')
+
+        return mac_prefix
+
     @staticmethod
     def validate_mac_prefix(mac_prefix):
         valid = len(mac_prefix) == 6


### PR DESCRIPTION
This PR introduces changes to ensure that the auto generated `mac_prefix` is valid in terms of it having the first bit in the first byte unset and the second bit in the first byte set.
Why we do this is because first bit `set` in the first byte represents multicast address from which a bridge is not able to learn and the second bit `set` represents local addresses which a jail is essentially. So we enforce this restriction now to make sure `mac_prefix` adheres to it.