### PR TITLE
NAS-105528 / 12.0 / Restart plugins after update (by sonicaj)

### DIFF
--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1944,14 +1944,10 @@ class IOCage:
                 ).fetch_update(*params)
             finally:
                 if not started and jail_type == 'pluginv2':
-                    plugin_obj = ioc_plugin.IOCPlugin(
-                        jail=uuid,
-                        plugin=conf['plugin_name'],
-                        git_repository=conf['plugin_repository'],
-                        callback=self.callback,
-                    )
-                    plugin_obj.stop_rc()
-                    plugin_obj.start_rc()
+                    silent = self.silent
+                    self.silent = True
+                    self.restart()
+                    self.silent = silent
 
             ioc_common.logit({
                 'level': 'INFO',


### PR DESCRIPTION
Earlier we used to restart rc's inside the jail but for dhcp based jails, that does not seem to work very well and we see issues where the services in plugins are not started properly.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [ ] Explain the feature
- [ ] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
