### PR TITLE
NAS-105608 / 12.0 / Make sure we handle ABI in packagesite gracefully (by sonicaj)

### DIFF
--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -198,7 +198,7 @@ class IOCPlugin(object):
         return version_dict
 
     @staticmethod
-    def retrieve_plugin_index_data(plugin_index_path):
+    def retrieve_plugin_index_data(plugin_index_path, expand_abi=True):
         plugin_index = {}
         index_path = os.path.join(plugin_index_path, 'INDEX')
         if not os.path.exists(index_path):
@@ -220,10 +220,9 @@ class IOCPlugin(object):
             if not any(plugin_manifest_data.get(k) for k in ('release', 'packagesite')):
                 continue
 
-            if '${ABI}' in plugin_manifest_data['packagesite']:
-                plugin_manifest_data['packagesite'] = plugin_manifest_data['packagesite'].replace(
-                    '${ABI}',
-                    f'FreeBSD:{plugin_manifest_data["release"].split("-")[0].split(".")[0]}:amd64'
+            if expand_abi and '${ABI}' in plugin_manifest_data['packagesite']:
+                plugin_manifest_data['packagesite'] = IOCPlugin.expand_abi_with_specified_release(
+                    plugin_manifest_data['packagesite'], plugin_manifest_data['release']
                 )
 
             plugin_index[plugin] = {
@@ -233,6 +232,12 @@ class IOCPlugin(object):
             }
 
         return plugin_index
+
+    @staticmethod
+    def expand_abi_with_specified_release(packagesite, release):
+        return packagesite.replace(
+            '${ABI}', f'FreeBSD:{release.split("-")[0].split(".")[0]}:amd64'
+        )
 
     def fetch_plugin_versions(self):
         self.pull_clone_git_repo()
@@ -1354,10 +1359,11 @@ fingerprint: {fingerprint}
 
     def _plugin_json_file(self):
         plugin_name = self.plugin.rsplit('_', 1)[0]
+        jail_name = self.jail or plugin_name
         try:
             with open(
                 os.path.join(
-                    self.iocroot, 'jails', plugin_name, f'{plugin_name}.json'
+                    self.iocroot, 'jails', jail_name, f'{plugin_name}.json'
                 ), 'r'
             ) as f:
                 manifest = json.loads(f.read())
@@ -1365,7 +1371,7 @@ fingerprint: {fingerprint}
             iocage_lib.ioc_common.logit(
                 {
                     'level': 'EXCEPTION',
-                    'message': f'Failed retrieving {plugin_name} json'
+                    'message': f'Failed retrieving {jail_name} json'
                 },
                 _callback=self.callback
             )


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 7223094b42622b2a3932dd55fc5827964ef49a38

This PR introduces changes to ensure that if we have `ABI` provided in the plugin manifest's packagesite, we expand it keeping in line with the `release` plugin is using.