### PR TITLE
NAS-105608 / 11.3 / Make sure we handle ABI in packagesite gracefully (by sonicaj) (by bugclerk)

### DIFF
--- a/.travis/flake8.sh
+++ b/.travis/flake8.sh
@@ -2,6 +2,7 @@
 # Run pep8 on all .py files in all subfolders
 
 tmpafter=$(mktemp)
+
 find ./iocage_cli ./iocage_lib -name \*.py -exec flake8 --max-line-length=120 --ignore=E127,E203,W503,F811,W504 {} + > ${tmpafter}
 num_errors_after=`cat ${tmpafter} | wc -l`
 echo "Current Error Count: ${num_errors_after}"
@@ -15,7 +16,7 @@ echo "Comparing with last stable release: ${last_release}"
 git checkout ${last_release}
 
 tmpbefore=$(mktemp)
-find ./iocage_cli ./iocage_lib -name \*.py -exec flake8 --ignore=E127,E203,W503,F811,W504 {} + > ${tmpbefore}
+find ./iocage_cli ./iocage_lib -name \*.py -exec flake8 --max-line-length=120 --ignore=E127,E203,W503,F811,W504 {} + > ${tmpbefore}
 num_errors_before=`cat ${tmpbefore} | wc -l`
 echo "${last_release}'s Error Count: ${num_errors_before}"
 

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -117,10 +117,7 @@ class IOCPlugin(object):
             )
 
         if self.branch is None and not self.hardened:
-            freebsd_version = su.run(['freebsd-version'],
-                                     stdout=su.PIPE,
-                                     stderr=su.STDOUT)
-            r = freebsd_version.stdout.decode().rstrip().split('-', 1)[0]
+            r = self.retrieve_freebsd_version()
 
             self.branch = f'{r}-RELEASE' if '.' in r else f'{r}.0-RELEASE'
         elif self.branch is None and self.hardened:
@@ -132,6 +129,12 @@ class IOCPlugin(object):
             self.branch, self.git_repository, self.git_destination,
             depth, self.callback
         )
+
+    @staticmethod
+    def retrieve_freebsd_version():
+        return su.run(
+            ['freebsd-version'], stdout=su.PIPE, stderr=su.STDOUT
+        ).stdout.decode().rstrip().split('-', 1)[0]
 
     @staticmethod
     def fetch_plugin_packagesites(package_sites):
@@ -207,12 +210,23 @@ class IOCPlugin(object):
             if not os.path.exists(plugin_manifest_path):
                 continue
 
+            with open(plugin_manifest_path, 'r') as f:
+                plugin_manifest_data = json.loads(f.read())
+
+            if not any(plugin_manifest_data.get(k) for k in ('release', 'packagesite')):
+                continue
+
+            if '${ABI}' in plugin_manifest_data['packagesite']:
+                plugin_manifest_data['packagesite'] = plugin_manifest_data['packagesite'].replace(
+                    '${ABI}',
+                    f'FreeBSD:{plugin_manifest_data["release"].split("-")[0].split(".")[0]}:amd64'
+                )
+
             plugin_index[plugin] = {
                 'primary_pkg': index[plugin].get('primary_pkg'),
                 'category': index[plugin].get('category'),
+                **plugin_manifest_data
             }
-            with open(plugin_manifest_path, 'r') as f:
-                plugin_index[plugin].update(json.loads(f.read()))
 
         return plugin_index
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 7223094b42622b2a3932dd55fc5827964ef49a38

This PR introduces changes to ensure that if we have `ABI` provided in the plugin manifest's packagesite, we expand it keeping in line with the `release` plugin is using.