### PR TITLE
NAS-105845 / 11.3 / Clean distutils dir cache before copy_tree (by fulder) (by bugclerk)

### DIFF
--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -1193,23 +1193,23 @@ fingerprint: {fingerprint}
                 f'{path}/plugin', callback=self.callback
             )
 
-        try:
-            distutils.dir_util._path_created = {}
-            distutils.dir_util.copy_tree(
-                f"{path}/plugin/overlay/",
-                f"{path}/root",
-                preserve_symlinks=True)
-        except distutils.errors.DistutilsFileError as e:
-            # It just doesn't exist
-            iocage_lib.ioc_common.logit(
-                {
-                    'level': 'INFO',
-                    'message': f'Error during overlay copy: {str(e)}'
-                },
-                _callback=self.callback,
-                silent=self.silent
-            )
-            pass
+        if os.path.isdir(f"{path}/plugin/overlay/"):
+            try:
+                distutils.dir_util._path_created = {}
+                distutils.dir_util.copy_tree(
+                    f"{path}/plugin/overlay/",
+                    f"{path}/root",
+                    preserve_symlinks=True)
+            except distutils.errors.DistutilsFileError as e:
+                # It just doesn't exist
+                iocage_lib.ioc_common.logit(
+                    {
+                        'level': 'EXCEPTION',
+                        'message': f'Error during overlay copy: {str(e)}'
+                    },
+                    _callback=self.callback,
+                    silent=self.silent
+                )
 
     def __update_pkg_remove__(self, jid):
         """Remove all pkgs from the plugin"""

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -1194,6 +1194,7 @@ fingerprint: {fingerprint}
             )
 
         try:
+            distutils.dir_util._path_created = {}
             distutils.dir_util.copy_tree(
                 f"{path}/plugin/overlay/",
                 f"{path}/root",

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -1199,8 +1199,16 @@ fingerprint: {fingerprint}
                 f"{path}/plugin/overlay/",
                 f"{path}/root",
                 preserve_symlinks=True)
-        except distutils.errors.DistutilsFileError:
+        except distutils.errors.DistutilsFileError as e:
             # It just doesn't exist
+            iocage_lib.ioc_common.logit(
+                {
+                    'level': 'INFO',
+                    'message': f'Error during overlay copy: {str(e)}'
+                },
+                _callback=self.callback,
+                silent=self.silent
+            )
             pass
 
     def __update_pkg_remove__(self, jid):

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -1195,13 +1195,16 @@ fingerprint: {fingerprint}
 
         if os.path.isdir(f"{path}/plugin/overlay/"):
             try:
+                # Quickfix for distutils cache bug making re-installed
+                # plugins with same name fail to copy the overlay folder
                 distutils.dir_util._path_created = {}
+
                 distutils.dir_util.copy_tree(
                     f"{path}/plugin/overlay/",
                     f"{path}/root",
                     preserve_symlinks=True)
             except distutils.errors.DistutilsFileError as e:
-                # It just doesn't exist
+                # Copy tree should succeed if the overlay folder exists
                 iocage_lib.ioc_common.logit(
                     {
                         'level': 'EXCEPTION',


### PR DESCRIPTION
While uninstalling a community plugin and reinstalling it with the same name there was a bug where the `overlay` folder didn't get applied to the fresh installed jail. The cause of this is probably a bug in the disutils library and how it caches the created folders.

During debugging and testing the following exception was raised: https://github.com/python/cpython/blob/master/Lib/distutils/dir_util.py#L73 but as it is ignored and not logged during the `copy_tree` call in `ioc_plugin.py` it was very hard to find what really happen (this is why I changed the try/except to log an exception and only copy it if the overlay folder exists).

The distutils exception was raised when it cached an overlay folder, shutil removed it during plugin removal and then while creating it again distutils thought it was already created and just skipped the creation (but the folder was not actually created)

What could be done as an alternative is shutil lib `copytree` function inside a helper function (with extended support for ignoring existing folders), but this would introduce too many changes so I kept it simple right now.

Note that this bug was only seen while using the UI. Please correct med if Im wrong, the UI is communicating with the jails using the `middelwared` service through a websocket channel. `middelwared` then uses `iocage` lib but from what I have seen it seems to somehow cache the python scripts as well (was forced to restart the `middelwared` service in order for my debug changes in `iocage` to take effect)? Using maybe the `.pyc` files? While running `iocage` CLI and the `destroy`/`fetch` commands I couldn't reproduce the issue, which maybe is logical, the disutils global cache variable is cleared during 2 different executions.

Related issues:
* https://github.com/ix-plugin-hub/iocage-plugin-index/issues/65#issuecomment-615463306
* https://stackoverflow.com/questions/9160227/dir-util-copy-tree-fails-after-shutil-rmtree
* https://stackoverflow.com/questions/1868714/how-do-i-copy-an-entire-directory-of-files-into-an-existing-directory-using-pyth

Should there maybe be a jira ticket for this issue as well?
(I can squash my commits before merge but wanted to keep them during review for easy revert)

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
