### PR TITLE
NAS-105735 / 11.3 / Use fstab.c to read fstab file contents (by sonicaj) (by bugclerk)

### DIFF
--- a/iocage_lib/utils.py
+++ b/iocage_lib/utils.py
@@ -1,5 +1,4 @@
 import six
-import sys
 
 from ctypes import CDLL
 from ctypes.util import find_library
@@ -22,5 +21,5 @@ def load_ctypes_library(name, signatures):
 
 def ensure_unicode_str(value):
     if not isinstance(value, six.text_type):
-        value = value.decode(sys.getfilesystemencoding())
+        value = value.decode()
     return value

--- a/iocage_lib/utils.py
+++ b/iocage_lib/utils.py
@@ -1,0 +1,26 @@
+import six
+import sys
+
+from ctypes import CDLL
+from ctypes.util import find_library
+
+
+def load_ctypes_library(name, signatures):
+    library_name = find_library(name)
+    if not library_name:
+        raise ImportError('No library named %s' % name)
+    lib = CDLL(library_name, use_errno=True)
+    # Add function signatures
+    for func_name, signature in signatures.items():
+        function = getattr(lib, func_name, None)
+        if function:
+            arg_types, restype = signature
+            function.argtypes = arg_types
+            function.restype = restype
+    return lib
+
+
+def ensure_unicode_string(value):
+    if not isinstance(value, six.text_type):
+        value = value.decode(sys.getfilesystemencoding())
+    return value

--- a/iocage_lib/utils.py
+++ b/iocage_lib/utils.py
@@ -20,7 +20,7 @@ def load_ctypes_library(name, signatures):
     return lib
 
 
-def ensure_unicode_string(value):
+def ensure_unicode_str(value):
     if not isinstance(value, six.text_type):
         value = value.decode(sys.getfilesystemencoding())
     return value


### PR DESCRIPTION
This PR introduces changes to ensure that we accept and deal with any valid fstab file. Right now we expect the file to have encoded characters for spaces etc, this change makes sure that we accept whatever the underlying OS is going to accept making the fstab handing more robust