### PR TITLE
NAS-106037 / 12.0 / Make MTU of VNet interfaces configurable (by nathanjrobertson)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-11-2-release-amd64
+  image_family: freebsd-11-3-snap
 
 iocage_tests_task:
   create_pool_script:

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -434,7 +434,7 @@ class IOCConfiguration:
     @staticmethod
     def get_version():
         """Sets the iocage configuration version."""
-        version = '27'
+        version = '28'
 
         return version
 
@@ -898,6 +898,13 @@ class IOCConfiguration:
         if not conf.get('min_dyn_devfs_ruleset'):
             conf['min_dyn_devfs_ruleset'] = '1000'
 
+        # Version 28 keys
+        for x in range(0, 4):
+            if not conf.get(f"vnet{x}_mtu"):
+                conf[f"vnet{x}_mtu"] = 'auto'
+        if not conf.get("vnet_default_mtu"):
+            conf["vnet_default_mtu"] = '1500'
+
         if not default:
             conf.update(jail_conf)
 
@@ -1236,6 +1243,11 @@ class IOCConfiguration:
             'plugin_name': 'none',
             'plugin_repository': 'none',
             'min_dyn_devfs_ruleset': '1000',
+            'vnet0_mtu': 'auto',
+            'vnet1_mtu': 'auto',
+            'vnet2_mtu': 'auto',
+            'vnet3_mtu': 'auto',
+            'vnet_default_mtu': '1500',
         }
 
     def check_default_config(self):
@@ -2152,6 +2164,11 @@ class IOCJson(IOCConfiguration):
             'plugin_name': ('string', ),
             'plugin_repository': ('string', ),
             'min_dyn_devfs_ruleset': ('string', ),
+            "vnet0_mtu": ("string", ),
+            "vnet1_mtu": ("string", ),
+            "vnet2_mtu": ("string", ),
+            "vnet3_mtu": ("string", ),
+            "vnet_default_mtu": ("string", ),
         }
 
         zfs_props = {

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -1180,10 +1180,12 @@ class IOCStart(object):
             nic, bridge = nic_def.split(":")
 
             try:
-                if not nat_addr:
+                if self.get(f"{nic}_mtu") != 'auto':
+                    membermtu = self.get(f"{nic}_mtu")
+                elif not nat_addr:
                     membermtu = self.find_bridge_mtu(bridge)
                 else:
-                    membermtu = '1500'
+                    membermtu = self.get('vnet_default_mtu')
 
                 dhcp = self.get('dhcp')
 
@@ -1571,7 +1573,7 @@ class IOCStart(object):
 
         memberif = self.get_bridge_members(bridge)
         if not memberif:
-            return '1500'
+            return self.get('vnet_default_mtu')
 
         membermtu = iocage_lib.ioc_common.checkoutput(
             ["ifconfig", memberif[0]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ def pytest_addoption(parser):
         help='Specify a zpool to use.'
     )
     parser.addoption(
-        '--release', action='store', default='11.2-RELEASE',
+        '--release', action='store', default='11.3-RELEASE',
         help='Specify a RELEASE to use.'
     )
     parser.addoption(

--- a/tests/unit_tests/1000_lib_start_test.py
+++ b/tests/unit_tests/1000_lib_start_test.py
@@ -52,7 +52,16 @@ def test_should_return_default_mtu_if_no_members(mock_checkoutput):
     mock_checkoutput.side_effect = [bridge_with_no_members_if_config,
                                     member_if_config]
 
-    mtu = ioc_start.IOCStart("", "", unit_test=True).find_bridge_mtu('bridge0')
+    # IOCStart.get() is not implemented in test mode. We need it for this test.
+    # So provide a dummy implementation which gives us the default MTU.
+    def _mock_iocstart_get(prop):
+        if prop=='vnet_default_mtu':
+            return "1500"
+        raise AttributeError(prop)
+
+    iocs = ioc_start.IOCStart("", "", unit_test=True)
+    iocs.get = _mock_iocstart_get
+    mtu = iocs.find_bridge_mtu('bridge0')
     assert mtu == '1500'
     mock_checkoutput.called_with(["ifconfig", "bridge0"])
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 5310084328dc8c410c1ed45ff9509ea6e1aad26a
    git cherry-pick -x cccf979b4f0259ffc92142294f0f8a78f5cbc1f4
    git cherry-pick -x 988d62066fd12472a57e14a3beab9755780e3e9c
    git cherry-pick -x 1cce79ebcd6bd0abeee361c3e894fcf25fde8c31
    git cherry-pick -x f2cc6568c978a3c971ca13935aab0a84bc962a4c
    git cherry-pick -x 1181a81a85cbd49fbbc5916b8d4b50be033b6a55
    git cherry-pick -x 760294893f2f856055f3186510dc4b6962b45c33
    git cherry-pick -x 89499f3ea336665226f56c29b0f3de7839104b9c
    git cherry-pick -x 717d7648ae98b5ff7a60232164169bdd4ec2a3d6
    git cherry-pick -x 3473e6b33fa4a5530330665e5950543687caa8b0
    git cherry-pick -x fae101d2d8decde7c3d60a51f849b2325fe817b2
    git cherry-pick -x 91cffa6ef8e70bf64e0d783e99edf4a6c4af54fc
    git cherry-pick -x cc3d08f90486e9ddb2a0ebde0251072ee74902d1
    git cherry-pick -x fd54062fdc55a34c2206d749a6014701c86e22b1

This patch adds five new configuration parameters, with the default behaviour being identical to the pre-existing behaviour (copy the MTU value from the bridge, or 1500 if there is no existing bridge). We add:

* vnet[0-3]_mtu - default to "auto" (ie. existing behaviour). If set to a value, it will take top precedence in creating the device (ie. it will ignore the value the bridge has)
* vnet_default_mtu - replaces the hardcoded "1500" value in the code with a configurable variable (but the variable defaults to "1500").

The use case we have for this where a bridge (say bridge0) has an IP address, and we bring it up on boot with that address (but no bridged NIC attached). if_bridge(4) says that you can't set the MTU on bridge0 with ifconfig - it is configured from the first attached device to the bridge. In our case, the VNet device ends up being the first attached, and this is hardcoded to 1500 (the VPS provider the machine runs on requires it to be 1450). Using one of the two above options (it seemed sensible to provide either a global or per-interface configuration) covers this situation.