### PR TITLE
NAS-106031 / 11.3 / Bug fixes for proper handling of custom devfs ruleset generation in plugins (by sonicaj)

### DIFF
--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -1113,6 +1113,39 @@ def get_host_gateways():
     return gateways
 
 
+def validate_plugin_manifest(manifest, _callback, silent):
+    errors = []
+    for k in (
+        'name', 'release', 'pkgs', 'packagesite', 'fingerprints', 'artifact',
+    ):
+        if k not in manifest:
+            errors.append(f'Missing "{k}" key in manifest')
+
+    if 'devfs_ruleset' in manifest:
+        if not isinstance(manifest['devfs_ruleset'], dict):
+            errors.append('"devfs_ruleset" must be a dictionary')
+        else:
+            devfs_ruleset = manifest['devfs_ruleset']
+            if 'paths' not in devfs_ruleset:
+                errors.append('Key "paths" not specified in devfs_ruleset')
+            elif not isinstance(devfs_ruleset['paths'], dict):
+                errors.append('"devfs_ruleset.paths" should be a valid dictionary')
+
+            if 'includes' in devfs_ruleset and not isinstance(devfs_ruleset['includes'], list):
+                errors.append('"devfs_ruleset.includes" should be a valid list')
+
+    if errors:
+        errors = '\n'.join(errors)
+        logit(
+            {
+                'level': 'EXCEPTION',
+                'msg': f'Following errors were encountered with plugin manifest:\n{errors}'
+            },
+            _callback=_callback,
+            silent=silent,
+        )
+
+
 def get_jails_with_config(filters=None, mapping_func=None):
     # FIXME: Due to how api is structured, there is no good place to put this
     #  so when we move on with restructuring the api, let's remove this as well

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -282,6 +282,7 @@ class IOCPlugin(object):
         """Helper to fetch plugins"""
         plugins = self.fetch_plugin_index(props, index_only=True)
         conf = self.retrieve_plugin_json()
+        iocage_lib.ioc_common.validate_plugin_manifest(conf, self.callback, self.silent)
 
         if self.hardened:
             conf['release'] = conf['release'].replace("-RELEASE", "-STABLE")
@@ -293,29 +294,6 @@ class IOCPlugin(object):
         location = f"{self.iocroot}/jails/{self.jail}"
 
         try:
-            devfs = conf.get("devfs_ruleset", None)
-
-            if devfs is not None:
-                plugin_devfs = devfs[f'plugin_{self.jail}']
-                plugin_devfs_paths = plugin_devfs['paths']
-
-                for prop in props:
-                    key, _, value = prop.partition("=")
-
-                    if key == 'dhcp' and iocage_lib.ioc_common.check_truthy(
-                        value
-                    ):
-                        if 'bpf*' not in plugin_devfs_paths:
-                            plugin_devfs_paths["bpf*"] = None
-
-                plugin_devfs_includes = None if 'includes' not in plugin_devfs\
-                    else plugin_devfs['includes']
-
-                iocage_lib.ioc_common.generate_devfs_ruleset(
-                    self.conf,
-                    paths=plugin_devfs_paths,
-                    includes=plugin_devfs_includes
-                )
             jaildir, _conf, repo_dir = self.__fetch_plugin_create__(props)
             self.__fetch_plugin_install_packages__(
                 jaildir, conf, pkg, props, repo_dir


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 465162ea5d54763b9d6639a5a47165ac0d9bf2be
    git cherry-pick -x 17cdce672d8f47e546574c9e2fcfcd6c4bc62cc9
    git cherry-pick -x 9dcd09186f18d841c1df8905e1157b6f74e08e82
    git cherry-pick -x aa460b5ccf6da0c7a3b1cc4ca326618cfa447731
    git cherry-pick -x 49e6280f67fb800251daa5373001af43a4818893
    git cherry-pick -x e6791b4e0370bd5935f1ef9786f9fcd852ff272a

This PR adds following changes :
1) Adds validation to ensure a plugin manifest is not malformed.
2) Makes sure that we are able to specify custom paths/includes for devfs ruleset generation for plugins in the plugin manifest.