### PR TITLE
NAS-106031 / 12.0 / Bug fixes for proper handling of custom devfs ruleset generation in plugins (by sonicaj)

### DIFF
--- a/doc/source/plugins.rst
+++ b/doc/source/plugins.rst
@@ -79,3 +79,48 @@ installed to a FreeNAS system, then the note of the plugin is changed:
 
 The process for upgrading and updating plugins is exactly the same as
 normal jails. See :ref:`Updating Jails` or :ref:`Upgrading Jails` .
+
+
+**Plugin Manifest Example**
+
+
+Following is an example of a plugin manifest:
+
+.. sourcecode:: json
+
+    {
+        "name": "default_jail_name_here",
+        "release": "11.3-RELEASE",
+        "artifact": "https://github.com/git_path_to_plugin_repo",
+        "official": false,
+        "properties": {
+            "nat": 1,
+            "nat_forwards": "tcp(7878:7878)"
+        },
+        "devfs_ruleset": {
+            "paths": {"bpf*": null},
+            "includes": []
+        },
+        "pkgs": [
+        ],
+        "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
+        "fingerprints": {
+            "iocage-plugins": [
+                {
+                    "function": "sha256",
+                    "fingerprint": "b0170035af3acc5f3f3ae1859dc717101b4e6c1d0a794ad554928ca0cbb2f438"
+                }
+            ]
+        },
+        "revision": "0"
+    }
+
+* **devfs_ruleset**: It should be a valid dictionary object where "paths" must be specified. Value of "paths" is a
+  dictionary where keys are the path to be added and the value is the mode to be used. `null` translates to `unhide`.
+  For any include specified, please refer to the following example which shows how each path specified is added as
+  iocage dynamically generates a devfs ruleset and how an include is added to the ruleset:
+
+.. sourcecode:: shell
+
+    devfs rule -s ruleset_number add path bpf* unhide
+    devfs rule -s ruleset_number add include include_value

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -1120,6 +1120,39 @@ def get_host_gateways():
     return gateways
 
 
+def validate_plugin_manifest(manifest, _callback, silent):
+    errors = []
+    for k in (
+        'name', 'release', 'pkgs', 'packagesite', 'fingerprints', 'artifact',
+    ):
+        if k not in manifest:
+            errors.append(f'Missing "{k}" key in manifest')
+
+    if 'devfs_ruleset' in manifest:
+        if not isinstance(manifest['devfs_ruleset'], dict):
+            errors.append('"devfs_ruleset" must be a dictionary')
+        else:
+            devfs_ruleset = manifest['devfs_ruleset']
+            if 'paths' not in devfs_ruleset:
+                errors.append('Key "paths" not specified in devfs_ruleset')
+            elif not isinstance(devfs_ruleset['paths'], dict):
+                errors.append('"devfs_ruleset.paths" should be a valid dictionary')
+
+            if 'includes' in devfs_ruleset and not isinstance(devfs_ruleset['includes'], list):
+                errors.append('"devfs_ruleset.includes" should be a valid list')
+
+    if errors:
+        errors = '\n'.join(errors)
+        logit(
+            {
+                'level': 'EXCEPTION',
+                'msg': f'Following errors were encountered with plugin manifest:\n{errors}'
+            },
+            _callback=_callback,
+            silent=silent,
+        )
+
+
 def get_jails_with_config(filters=None, mapping_func=None):
     # FIXME: Due to how api is structured, there is no good place to put this
     #  so when we move on with restructuring the api, let's remove this as well

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -1146,7 +1146,7 @@ def validate_plugin_manifest(manifest, _callback, silent):
         logit(
             {
                 'level': 'EXCEPTION',
-                'msg': f'Following errors were encountered with plugin manifest:\n{errors}'
+                'msg': f'The Following errors were encountered with plugin manifest:\n{errors}'
             },
             _callback=_callback,
             silent=silent,

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -282,6 +282,7 @@ class IOCPlugin(object):
         """Helper to fetch plugins"""
         plugins = self.fetch_plugin_index(props, index_only=True)
         conf = self.retrieve_plugin_json()
+        iocage_lib.ioc_common.validate_plugin_manifest(conf, self.callback, self.silent)
 
         if self.hardened:
             conf['release'] = conf['release'].replace("-RELEASE", "-STABLE")
@@ -293,29 +294,6 @@ class IOCPlugin(object):
         location = f"{self.iocroot}/jails/{self.jail}"
 
         try:
-            devfs = conf.get("devfs_ruleset", None)
-
-            if devfs is not None:
-                plugin_devfs = devfs[f'plugin_{self.jail}']
-                plugin_devfs_paths = plugin_devfs['paths']
-
-                for prop in props:
-                    key, _, value = prop.partition("=")
-
-                    if key == 'dhcp' and iocage_lib.ioc_common.check_truthy(
-                        value
-                    ):
-                        if 'bpf*' not in plugin_devfs_paths:
-                            plugin_devfs_paths["bpf*"] = None
-
-                plugin_devfs_includes = None if 'includes' not in plugin_devfs\
-                    else plugin_devfs['includes']
-
-                iocage_lib.ioc_common.generate_devfs_ruleset(
-                    self.conf,
-                    paths=plugin_devfs_paths,
-                    includes=plugin_devfs_includes
-                )
             jaildir, _conf, repo_dir = self.__fetch_plugin_create__(props)
             self.__fetch_plugin_install_packages__(
                 jaildir, conf, pkg, props, repo_dir

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -304,7 +304,7 @@ class IOCPlugin(object):
             status, jid = iocage_lib.ioc_list.IOCList().list_get_jid(self.jail)
             if status:
                 iocage_lib.ioc_stop.IOCStop(
-                    self.jail, jaildir, silent=self.silent, force=True, callback=self.callback
+                    self.jail, jaildir, silent=True, force=True, callback=self.callback
                 )
             with open(os.path.join(jaildir, f'{self.plugin}.json'), 'w') as f:
                 f.write(json.dumps(conf, indent=4, sort_keys=True))

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -44,7 +44,10 @@ import iocage_lib.ioc_common
 import iocage_lib.ioc_create
 import iocage_lib.ioc_destroy
 import iocage_lib.ioc_exec
+import iocage_lib.ioc_list
 import iocage_lib.ioc_json
+import iocage_lib.ioc_start
+import iocage_lib.ioc_stop
 import iocage_lib.ioc_upgrade
 import iocage_lib.ioc_exceptions
 import texttable
@@ -298,8 +301,14 @@ class IOCPlugin(object):
             # As soon as we create the jail, we should write the plugin manifest to jail directory
             # This is done to ensure that subsequent starts of the jail make use of the plugin
             # manifest as required
+            status, jid = iocage_lib.ioc_list.IOCList().list_get_jid(self.jail)
+            if status:
+                iocage_lib.ioc_stop.IOCStop(
+                    self.jail, jaildir, silent=self.silent, force=True, callback=self.callback
+                )
             with open(os.path.join(jaildir, f'{self.plugin}.json'), 'w') as f:
                 f.write(json.dumps(conf, indent=4, sort_keys=True))
+
             self.__fetch_plugin_install_packages__(
                 jaildir, conf, pkg, props, repo_dir
             )

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -295,6 +295,11 @@ class IOCPlugin(object):
 
         try:
             jaildir, _conf, repo_dir = self.__fetch_plugin_create__(props)
+            # As soon as we create the jail, we should write the plugin manifest to jail directory
+            # This is done to ensure that subsequent starts of the jail make use of the plugin
+            # manifest as required
+            with open(os.path.join(jaildir, f'{self.plugin}.json'), 'w') as f:
+                f.write(json.dumps(conf, indent=4, sort_keys=True))
             self.__fetch_plugin_install_packages__(
                 jaildir, conf, pkg, props, repo_dir
             )
@@ -771,11 +776,6 @@ fingerprint: {fingerprint}
                 silent=self.silent)
 
             self.__update_pull_plugin_artifact__(conf)
-
-            with open(
-                f"{jaildir}/{self.plugin}.json", "w"
-            ) as f:
-                f.write(json.dumps(conf, indent=4, sort_keys=True))
 
             try:
                 shutil.copy(f"{jaildir}/plugin/post_install.sh",

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -491,21 +491,13 @@ class IOCStart(object):
         devfs_paths = None
         devfs_includes = None
 
-        if self.conf['type'] == 'pluginv2' and os.path.isfile(
-            os.path.join(self.path, f'{self.conf["plugin_name"]}.json')
-        ):
-            with open(
-                os.path.join(self.path, f'{self.conf["plugin_name"]}.json'),
-                'r'
-            ) as f:
+        manifest_path = os.path.join(self.path, f'{self.conf["plugin_name"]}.json')
+        if self.conf['type'] == 'pluginv2' and os.path.isfile(manifest_path):
+            with open(manifest_path, 'r') as f:
                 devfs_json = json.load(f)
-                if "devfs_ruleset" in devfs_json:
-                    plugin_name = self.conf['plugin_name']
-                    plugin_devfs = devfs_json[
-                        "devfs_ruleset"][f"plugin_{plugin_name}"]
-                    devfs_paths = plugin_devfs['paths']
-                    devfs_includes = None if 'includes' not in \
-                        plugin_devfs else plugin_devfs['includes']
+            iocage_lib.ioc_common.validate_plugin_manifest(devfs_json, self.callback, self.silent)
+            devfs_paths = devfs_json.get('devfs_ruleset', {}).get('paths')
+            devfs_includes = devfs_json.get('devfs_ruleset', {}).get('includes')
 
         # Generate dynamic devfs ruleset from configured one
         (manual_devfs_config, configured_devfs_ruleset, devfs_ruleset) \


### PR DESCRIPTION
This PR adds following changes :
1) Adds validation to ensure a plugin manifest is not malformed.
2) Makes sure that we are able to specify custom paths/includes for devfs ruleset generation for plugins in the plugin manifest.