### PR TITLE
NAS-106134 / 11.3 / Allow users to use 0 default devfs ruleset

### DIFF
--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -752,7 +752,7 @@ def generate_devfs_ruleset(conf, paths=None, includes=None, callback=None,
     ruleset_list = [int(i) for i in devfs_rulesets.stdout.splitlines()]
 
     if ruleset != '4':
-        if int(ruleset) in ruleset_list:
+        if int(ruleset) == 0 or int(ruleset) in ruleset_list:
             return str(ruleset)
 
         logit({


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [ ] Explain the feature
- [ ] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
