### PR TITLE
NAS-106134 / 12.0 / Allow using 0 devfs ruleset (by sonicaj)

### DIFF
--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -762,8 +762,8 @@ def generate_devfs_ruleset(conf, paths=None, includes=None, callback=None,
 
     # Custom devfs_ruleset configured, clone to dynamic ruleset
     if int(configured_ruleset) != IOCAGE_DEVFS_RULESET:
-        if int(configured_ruleset) not in ruleset_list:
-            return (True, configured_ruleset, '0')
+        if int(configured_ruleset) != 0 and int(configured_ruleset) not in ruleset_list:
+            return True, configured_ruleset, '-1'
         rules = su.run(
             ['devfs', 'rule', '-s', configured_ruleset, 'show'],
             stdout=su.PIPE, universal_newlines=True

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -2450,7 +2450,7 @@ class IOCJson(IOCConfiguration):
                 elif key in ('devfs_ruleset', 'min_dyn_devfs_ruleset'):
                     try:
                         intval = int(value)
-                        if intval <= 0:
+                        if intval < 0:
                             raise ValueError()
                         conf[key] = str(intval)
                     except ValueError:

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -504,7 +504,7 @@ class IOCStart(object):
             = iocage_lib.ioc_common.generate_devfs_ruleset(
                 self.conf, devfs_paths, devfs_includes)
 
-        if int(devfs_ruleset) <= 0:
+        if int(devfs_ruleset) < 0:
             iocage_lib.ioc_common.logit({
                 "level": "ERROR",
                 "message": f"{self.uuid} devfs_ruleset"


### PR DESCRIPTION
FreeBSD provides 0 as a default ruleset for mountpoints. Allow using 0 ruleset for jails.

