### PR TITLE
NAS-106610 / 12.0 / Move plugins from official plugins list to community plugins (by sonicaj)

### DIFF
--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -738,7 +738,9 @@ class IOCConfiguration:
                 'channels-dvr', 'dnsmasq', 'homebridge', 'irssi', 'madsonic',
                 'openvpn', 'quasselcore', 'rtorrent-flood', 'sickchill',
                 'unificontroller', 'unificontroller-lts', 'weechat', 'xmrig',
-                'radarr', 'sonarr',
+                'radarr', 'sonarr', 'backuppc', 'clamav', 'couchpotato', 'emby',
+                'jenkins', 'jenkins-lts', 'mineos', 'transmission', 'tautulli',
+                'qbittorrent', 'zoneminder',
             ) and conf['plugin_repository'] in official_repo:
                 conf['plugin_repository'] = \
                     'https://github.com/ix-plugin-hub/iocage-plugin-index.git'

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -738,6 +738,7 @@ class IOCConfiguration:
                 'channels-dvr', 'dnsmasq', 'homebridge', 'irssi', 'madsonic',
                 'openvpn', 'quasselcore', 'rtorrent-flood', 'sickchill',
                 'unificontroller', 'unificontroller-lts', 'weechat', 'xmrig',
+                'radarr', 'sonarr',
             ) and conf['plugin_repository'] in official_repo:
                 conf['plugin_repository'] = \
                     'https://github.com/ix-plugin-hub/iocage-plugin-index.git'


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 4e0d06d16a57b038fa3a1da620399c0dfdb9385f

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [ ] Explain the feature
- [ ] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
