### PR TITLE
NAS-106822 / 12.0 / Use path to determine plugin version (by sonicaj)

### DIFF
--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -58,7 +58,7 @@ from iocage_lib.dataset import Dataset
 
 
 GIT_LOCK = threading.Lock()
-RE_PLUGIN_VERSION = re.compile(r'"name"\s*:\s*"([\.\+\w-]*)".*"version"\s*:\s*"([\d,\.\+\w]*)"')
+RE_PLUGIN_VERSION = re.compile(r'"path":"([/\.\+,\d\w-]*)\.txz"')
 
 
 class IOCPlugin(object):
@@ -173,11 +173,10 @@ class IOCPlugin(object):
                             searched = RE_PLUGIN_VERSION.findall(line)
                             if not searched:
                                 continue
+                            name = searched[0].rsplit('/', 1)[-1]
                             package_site_data[
-                                searched[0][0]
-                            ] = iocage_lib.ioc_common.parse_package_name(
-                                f'{searched[0][0]}-{searched[0][1]}'
-                            )
+                                name.rsplit('-', 1)[0]
+                            ] = iocage_lib.ioc_common.parse_package_name(name)
             except Exception:
                 pass
 


### PR DESCRIPTION
Some pkgs have dependencies with versions listed and in this case the regex being used is unable to determine which version is actually the main pkg ones. We take a different approach and use path of the pkg to determine pkg version.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [ ] Explain the feature
- [ ] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
