### PR TITLE
NAS-106965 / 11.3 / Make sure we don't mark a succcessful package installation as failed (by sonicaj)

### DIFF
--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -947,6 +947,7 @@ class IOCCreate(object):
 
             pkg_retry = 1
             while True:
+                pkg_err = False
                 cmd = ("/usr/local/sbin/pkg", "install", "-q", "-y", pkg)
 
                 try:


### PR DESCRIPTION
If a package fails to install, we output subsequent successful package installation as failed whereas in reality they have not failed as the flag is being reused.
