### PR TITLE
NAS-107112 / 12.0 / Strip newline from plugin-properties (by jsegaert)

### DIFF
--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -2574,7 +2574,7 @@ class IOCJson(IOCConfiguration):
                             _exec,
                             log=False
                         )
-                        return output['stdout'][0] if output['stdout'] else ''
+                        return (output['stdout'][0]).rstrip("\n") if output['stdout'] else ''
             else:
                 return settings
         except KeyError:


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

Fixes #1163

Fixes the regression reported as per #1163.  Both the Zoneminder and MineOS community plugins would like to leverage this functionality.  Can this please be ported to the FreeNAS/TrueNAS 12 branch?  

The issue manifests itself as follows:
1) In `iocage fetch`, the Admin Portal has linebreak in the post-install notes
```
➜  ~ sudo iocage fetch -P mineos.json -n mineos nat=1 --branch=experimental
Plugin: mineos
  Official Plugin: False
  Using RELEASE: 11.3-RELEASE
  Using Branch: experimental
  Post-install Artifact: https://github.com/jsegaert/iocage-plugin-mineos.git
  These pkgs will be installed:
    - sysutils/py-rdiff-backup
    - sysutils/screen
    - net/rsync
    - devel/gmake
    - devel/git-lite
    - lang/python3
    - www/node10
    - www/npm-node10
    - java/openjdk8-jre
    - ftp/wget
    - shells/bash
 
 (snip)
 The default user for the Admin Portal is "mcserver" with password "mcserver"
5 warnings generated.

Admin Portal:
http
://192.168.0.167:8443


Doc URL:
https://github.com/jsegaert/iocage-plugin-mineos/tree/master#iocage-plugin-mineos
```

2) `iocage list -P` shows Admin Portal with linebreak
```
➜  ~ sudo iocage list -P
+-----+--------+------+-------+----------+-----------------+---------------------+-----+----------+-----------------------+-----------------------------------------------------------------------------------+
| JID |  NAME  | BOOT | STATE |   TYPE   |     RELEASE     |         IP4         | IP6 | TEMPLATE |        PORTAL         |                                      DOC_URL                                      |
+=====+========+======+=======+==========+=================+=====================+=====+==========+=======================+===================================================================================+
| 6   | mineos | on   | up    | pluginv2 | 11.3-RELEASE-p7 | vnet0|172.16.0.2/30 | -   | -        | http                  | https://github.com/jsegaert/iocage-plugin-mineos/tree/master#iocage-plugin-mineos |
|     |        |      |       |          |                 |                     |     |          | ://192.168.0.167:8443 |                                                                                   |
|     |        |      |       |          |                 |                     |     |          |                       |                                                                                   |
+-----+--------+------+-------+----------+-----------------+---------------------+-----+----------+-----------------------+-----------------------------------------------------------------------------------+
```

3) Any plugin properties requested via `iocage get -P` have a linebreak, where regular jail properties do not:
```
➜  ~ sudo iocage get boot mineos
1
➜  ~ sudo iocage get -P port mineos
8443

➜  ~ 
```

