### PR TITLE
NAS-106984 / 12.0 / Donot set hostname in rc.conf (by sonicaj)

### DIFF
--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -1038,10 +1038,6 @@ ipv6_activate_all_interfaces=\"YES\"
             su.Popen(
                 ['mount', '-F', f'{location}/fstab', '-a']).communicate()
 
-        su.Popen(['sysrc', '-f', f'{location}/root/etc/rc.conf',
-                  f'hostname={host_hostname.replace("_", "-")}'],
-                 stdout=su.PIPE).communicate()
-
         if basejail:
             su.Popen(
                 ['umount', '-F', f'{location}/fstab', '-a']).communicate()


### PR DESCRIPTION
When a jail is created, we set the hostname in rc.conf for each jail, however this means that the value specified in host.hostname never gets respected. So we should either be setting the hostname in rc file each time the jail starts or default to using host.hostname. I propose the latter as I think we should not be making decisions on the user's behalf where he/she might override it in rc.conf his/herself.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [ ] Explain the feature
- [ ] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
