### PR TITLE
NAS-107433 / 12.0 / Correctly handle locks for eliminating a new race condition (by sonicaj)

### DIFF
--- a/iocage_lib/cache.py
+++ b/iocage_lib/cache.py
@@ -28,8 +28,13 @@ class Cache:
 
     @property
     def iocage_activated_pool(self):
-        pools = self.pools
-        with self.cache_lock:
+        return self.iocage_activated_pool_internal()
+
+    def iocage_activated_pool_internal(self, lock=True):
+        if lock:
+            self.cache_lock.acquire()
+        try:
+            pools = self.pools_internal(lock=False)
             self.dataset_data = self.dataset_data or {}
             if not self.ioc_pool:
                 if not all(self.dataset_data.get(p) for p in pools):
@@ -42,22 +47,25 @@ class Cache:
                 ):
                     self.ioc_pool = p
             return self.ioc_pool
+        finally:
+            if lock:
+                self.cache_lock.release()
 
     @property
     def iocage_activated_dataset(self):
-        ioc_pool = self.iocage_activated_pool
-        if ioc_pool:
-            dependents = self.dependents(ioc_pool, 1)
-            ioc_ds = os.path.join(ioc_pool, 'iocage')
         with self.cache_lock:
+            ioc_pool = self.iocage_activated_pool_internal(lock=False)
+            if ioc_pool:
+                dependents = self.dependents_internal(ioc_pool, 1, lock=False)
+                ioc_ds = os.path.join(ioc_pool, 'iocage')
             if not self.ioc_dataset and ioc_pool and ioc_ds in dependents:
                 self.ioc_dataset = ioc_ds
             return self.ioc_dataset
 
     @property
     def datasets(self):
-        ioc_pool = self.iocage_activated_pool
         with self.cache_lock:
+            ioc_pool = self.iocage_activated_pool_internal(lock=False)
             if not self.dataset_data or set(self.dataset_data) == set(self.pool_data):
                 ds = ''
                 if ioc_pool:
@@ -68,7 +76,12 @@ class Cache:
             return self.dataset_data
 
     def dependents(self, dataset, depth=None):
-        with self.cache_lock:
+        return self.dependents_internal(dataset, depth)
+
+    def dependents_internal(self, dataset, depth=None, lock=True):
+        if lock:
+            self.cache_lock.acquire()
+        try:
             if not self.dataset_dep_data:
                 self.dataset_dep_data = {}
                 for ds in get_all_dependents():
@@ -80,6 +93,9 @@ class Cache:
             return get_dependents_with_depth(
                 dataset, self.dataset_dep_data.get(dataset, []), depth
             )
+        finally:
+            if lock:
+                self.cache_lock.release()
 
     def update_dataset_data(self, dataset, props):
         with self.cache_lock:
@@ -88,10 +104,18 @@ class Cache:
 
     @property
     def pools(self):
-        with self.cache_lock:
+        return self.pools_internal()
+
+    def pools_internal(self, lock=True):
+        if lock:
+            self.cache_lock.acquire()
+        try:
             if not self.pool_data:
                 self.pool_data = all_properties(resource_type='zpool')
             return self.pool_data
+        finally:
+            if lock:
+                self.cache_lock.release()
 
     def reset(self):
         with self.cache_lock:


### PR DESCRIPTION
When using iocage's library it's possible that the consumer resets the cache and another thread is in the middle of accessing it resulting in undesired behaviour.


Original PR: https://github.com/iocage/iocage/pull/1207