### PR TITLE
NAS-107687 / 12.0 / Donot use cache for snapshot resource

### DIFF
--- a/iocage_lib/dataset.py
+++ b/iocage_lib/dataset.py
@@ -114,6 +114,7 @@ class Snapshot(Resource):
     zfs_resource = 'zfs'
 
     def __init__(self, *args, **kwargs):
+        kwargs['cache'] = False
         super().__init__(*args, **kwargs)
         if '@' in self.resource_name:
             self.name = self.resource_name.split('@', 1)[-1]


### PR DESCRIPTION
Users can likely have thousands of snapshots which if we cache takes precious time. Snapshot related tasks are quite a few and are mostly used by CLI users as middleware does not consume that interface.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [ ] Explain the feature
- [ ] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
