### PR TITLE
NAS-108115 / 12.0 / Properly retrieve configured devfs_ruleset for jails having fullstop …

### DIFF
--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -1731,7 +1731,7 @@ class IOCJson(IOCConfiguration):
             elif prop == 'devfs_ruleset' and state:
                 ruleset = su.check_output(
                     [
-                        'jls', '-j', f'ioc-{conf["host_hostuuid"]}',
+                        'jls', '-j', f'ioc-{conf["host_hostuuid"].replace(".", "_")}',
                         'devfs_ruleset'
                     ]
                 ).decode().rstrip()

--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -54,7 +54,7 @@ class IOCStop(object):
             self.conf = iocage_lib.ioc_json.IOCJson(
                 path, suppress_log=True).json_get_value('all')
             self.status, self.jid = iocage_lib.ioc_list.IOCList().list_get_jid(
-                uuid)
+                self.uuid)
             self.nics = self.conf['interfaces']
             self.__stop_jail__()
         except (Exception, SystemExit) as e:


### PR DESCRIPTION
…in name

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [ ] Explain the feature
- [ ] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
