### PR TITLE
NAS-108747 / 12.0 / Handle case where pool may not be mounted

### DIFF
--- a/iocage_lib/cache.py
+++ b/iocage_lib/cache.py
@@ -42,10 +42,14 @@ class Cache:
                         all_properties([p for p in pools], types=['filesystem'])
                     )
                 for p in filter(
-                    lambda p: self.dataset_data.get(p, {}).get('org.freebsd.ioc:active') == 'yes',
-                    pools
+                    lambda p: (
+                        p.get('org.freebsd.ioc:active') == 'yes' and p.get('mounted') == 'yes' and not(
+                            p.get('encryption', 'off') != 'off' and p.get('keystatus', 'available') != 'available'
+                        )
+                    ),
+                    map(lambda p: {**self.dataset_data.get(p, {}), 'name': p}, pools)
                 ):
-                    self.ioc_pool = p
+                    self.ioc_pool = p['name']
             return self.ioc_pool
         finally:
             if lock:


### PR DESCRIPTION
In a situation where there are multiple pools both showing up as activated for iocage and one of the pools is umounted, that results in cache and iocage pool logic getting out of sync resuling in various errors

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [ ] Explain the feature
- [ ] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
