### PR TITLE
Add an option to setup mountpoints when fetching a plugin

### DIFF
--- a/iocage_cli/fetch.py
+++ b/iocage_cli/fetch.py
@@ -150,6 +150,12 @@ def validate_count(ctx, param, value):
     '--proxy', '-S', default=None,
     help='Provide proxy to use for creating jail'
 )
+@click.option(
+    "--mountpoints", "-M", multiple=True,
+    help="Specify a mountpoint to setup in the jail. Format is "
+         "source:destination[:options].\n(only applicable if "
+         "fetching a plugin)"
+)
 def cli(**kwargs):
     """CLI command that calls fetch_release()"""
     release = kwargs.get("release", None)


### PR DESCRIPTION
Add the option --mountpoints/-M to the fetch subcommand. It gives the
possibility to setup one or many mountpoints at the jail creation of
a plugin, before the initial start. It mimicks the format of the Docker
--volume option: source:destination[:options]

Example:
  iocage fetch -P ./plugin.json -M /mnt/tank/plugin-data:/data:ro